### PR TITLE
improve hot reload system

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A tool for experimenting with WGSL shaders, it uses `wgpu` for rendering, `egui`
 
 ### Current Features
 
-- Hot shader reloading (crash if you make errors: WIP)
+- Hot shader reloading
 - Multi-pass, atomics etc
 - Interactive parameter adjustment, ez Texture loading through egui
 - Export HQ frames via egui

--- a/usage.md
+++ b/usage.md
@@ -140,7 +140,7 @@ fn fs_pass2(...) -> @location(0) vec4<f32> {
 
 
 ### Hot Reloading
-cuneus supports hot reloading of shaders. Simply modify your WGSL files and they will automatically reload. For now, it crashes if you make an error. 
+cuneus supports hot reloading of shaders. Simply modify your WGSL files and they will automatically reload.
 
 ### Export Support
 Built-in support for exporting frames as images. Access through the UI when enabled. "Start time" is not working correctly currently.


### PR DESCRIPTION
https://github.com/altunenes/cuneus/issues/14

Problem solved by:

Old: `Result<wgpu::ShaderModule, String>` - Could panic
New: `Option<wgpu::ShaderModule>` - Never panics

Old: Passed through wgpu errors directly
New: Catches panics using `catch_unwind` and converts them to `None`