### PR TITLE
Fix: use consistent RGBA format throughout the pipeline

### DIFF
--- a/src/base_shader.rs
+++ b/src/base_shader.rs
@@ -313,18 +313,16 @@ impl BaseShader {
             mip_level_count: 1,
             sample_count: 1,
             dimension: wgpu::TextureDimension::D2,
-            format: wgpu::TextureFormat::Bgra8UnormSrgb,
+            format: wgpu::TextureFormat::Rgba8UnormSrgb,
             usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
             view_formats: &[],
         });
-
-        // Calculate padded bytes per row 
+        //per row for buffer alignment
         let align = 256;
         let unpadded_bytes_per_row = width * 4;
         let padding = (align - unpadded_bytes_per_row % align) % align;
         let padded_bytes_per_row = unpadded_bytes_per_row + padding;
-
-        // buffer with padded size
+    
         let buffer_size = padded_bytes_per_row * height;
         let output_buffer = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("Capture Buffer"),
@@ -332,7 +330,7 @@ impl BaseShader {
             usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
             mapped_at_creation: false,
         });
-
+    
         (capture_texture, output_buffer)
     }
     pub fn apply_control_request(&mut self, request: ControlsRequest) {

--- a/src/bin/asahi.rs
+++ b/src/bin/asahi.rs
@@ -122,17 +122,12 @@ impl ChristmasShader {
         Ok(unpadded_data)
     }
 
-    fn save_frame(&self, mut data: Vec<u8>, frame: u32, settings: &ExportSettings) -> Result<(), ExportError> {
+    fn save_frame(&self, data: Vec<u8>, frame: u32, settings: &ExportSettings) -> Result<(), ExportError> {
         let frame_path = settings.export_path
             .join(format!("frame_{:05}.png", frame));
         
         if let Some(parent) = frame_path.parent() {
             std::fs::create_dir_all(parent)?;
-        }
-
-        // Convert BGRA to RGBA
-        for chunk in data.chunks_mut(4) {
-            chunk.swap(0, 2);
         }
 
         let image = image::ImageBuffer::<image::Rgba<u8>, Vec<u8>>::from_raw(


### PR DESCRIPTION
- use consistent RGBA format throughout the pipeline