### PR TITLE
new example: Segment-based Color Extraction from a scene

### DIFF
--- a/shaders/scenecolor.wgsl
+++ b/shaders/scenecolor.wgsl
@@ -1,0 +1,69 @@
+// MIT License, Enes Altun, 2025
+@group(0) @binding(0) var tex: texture_2d<f32>;
+@group(0) @binding(1) var tex_sampler: sampler;
+@group(1) @binding(0) var<uniform> u_time: TimeUniform;
+@group(2) @binding(0) var<uniform> params: Params;
+@group(3) @binding(0) var<uniform> u_resolution: ResolutionUniform;
+
+struct ResolutionUniform {
+    dimensions: vec2<f32>,
+    _padding: vec2<f32>,
+};
+
+struct TimeUniform {
+    time: f32,
+};
+
+struct Params {
+    // Palette settings
+    num_segments: f32,
+    palette_height: f32,
+    samples_x: i32,
+    samples_y: i32,
+    
+    _pad1: f32,
+    _pad2: f32,
+    _pad3: f32,
+    _pad4: f32,
+};
+
+fn mix(a: f32, b: f32, t: f32) -> f32 {
+    return a * (1.0 - t) + b * t;
+}
+
+@fragment
+fn fs_main(@builtin(position) fragCoord: vec4<f32>) -> @location(0) vec4<f32> {
+    let dimensions = u_resolution.dimensions;
+    let uv = fragCoord.xy / dimensions;
+    
+    // original texture in the main area
+    if (uv.y <= (1.0 - params.palette_height)) {
+        return textureSample(tex, tex_sampler, uv);
+    }
+    
+    // I m going to create a plate on bottom, this can be adjustable via egui
+    let segmentWidth = dimensions.x / params.num_segments;
+    let segmentIndex = i32(fragCoord.x / segmentWidth);
+    
+
+    let startX = f32(segmentIndex) / params.num_segments;
+    let endX = f32(segmentIndex + 1) / params.num_segments;
+    
+    // average color for this segment
+    var avgColor = vec3<f32>(0.0);
+    var sampleCount = 0;
+    
+    // Sample evenly across the vertical dimension and within the segment horizontally
+    for (var y = 0; y < params.samples_y; y = y + 1) {
+        let sampleY = f32(y) / f32(params.samples_y - 1);
+        for (var x = 0; x < params.samples_x; x = x + 1) {
+            // Sample within the segment's horizontal range
+            let sampleX = mix(startX, endX, f32(x) / f32(params.samples_x - 1));
+            avgColor += textureSample(tex, tex_sampler, vec2<f32>(sampleX, sampleY)).rgb;
+            sampleCount = sampleCount + 1;
+        }
+    }
+    // Calculate the average
+    avgColor = avgColor / f32(sampleCount);
+    return vec4<f32>(avgColor, 1.0);
+}

--- a/src/bin/scenecolor.rs
+++ b/src/bin/scenecolor.rs
@@ -1,0 +1,467 @@
+use cuneus::{Core,Renderer,ShaderApp, ShaderManager, UniformProvider, UniformBinding, BaseShader,ExportSettings, ExportError, ExportManager,ShaderHotReload,ShaderControls};
+use winit::event::*;
+use image::ImageError;
+use std::path::PathBuf;
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
+struct ShaderParams {
+    num_segments: f32,
+    palette_height: f32,
+    samples_x: i32,
+    samples_y: i32,
+    
+    // Extra padding to avoid buffer size issues
+    _pad1: f32,
+    _pad2: f32,
+    _pad3: f32,
+    _pad4: f32,
+}
+
+impl UniformProvider for ShaderParams {
+    fn as_bytes(&self) -> &[u8] {
+        bytemuck::bytes_of(self)
+    }
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    cuneus::gst::init()?;
+    env_logger::init();
+    let (app, event_loop) = ShaderApp::new("scenecolor", 800, 600);
+    let shader = SpiralShader::init(app.core());
+    app.run(event_loop, shader)
+}
+
+struct SpiralShader {
+    base: BaseShader,
+    params_uniform: UniformBinding<ShaderParams>,
+    hot_reload: ShaderHotReload,
+    texture_bind_group_layout: wgpu::BindGroupLayout,
+    time_bind_group_layout: wgpu::BindGroupLayout,
+    resolution_bind_group_layout: wgpu::BindGroupLayout,
+    params_bind_group_layout: wgpu::BindGroupLayout,
+}
+
+impl SpiralShader {
+    fn capture_frame(&mut self, core: &Core, time: f32) -> Result<Vec<u8>, wgpu::SurfaceError> {
+        let settings = self.base.export_manager.settings();
+        let (capture_texture, output_buffer) = self.base.create_capture_texture(
+            &core.device,
+            settings.width,
+            settings.height
+        );
+        let align = 256;
+        let unpadded_bytes_per_row = settings.width * 4;
+        let padding = (align - unpadded_bytes_per_row % align) % align;
+        let padded_bytes_per_row = unpadded_bytes_per_row + padding;
+        let capture_view = capture_texture.create_view(&wgpu::TextureViewDescriptor::default());
+        let mut encoder = core.device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("Capture Encoder"),
+        });
+        self.base.time_uniform.data.time = time;
+        self.base.time_uniform.update(&core.queue);
+        self.base.resolution_uniform.data.dimensions = [settings.width as f32, settings.height as f32];
+        self.base.resolution_uniform.update(&core.queue);
+        {
+            let mut render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("Capture Pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: &capture_view,
+                    resolve_target: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
+            });
+            render_pass.set_pipeline(&self.base.renderer.render_pipeline);
+            render_pass.set_vertex_buffer(0, self.base.renderer.vertex_buffer.slice(..));
+            if self.base.using_video_texture {
+                if let Some(video_manager) = &self.base.video_texture_manager {
+                    render_pass.set_bind_group(0, &video_manager.texture_manager().bind_group, &[]);
+                }
+            } else if let Some(texture_manager) = &self.base.texture_manager {
+                render_pass.set_bind_group(0, &texture_manager.bind_group, &[]);
+            }
+            // Time (group 1)
+            render_pass.set_bind_group(1, &self.base.time_uniform.bind_group, &[]);
+            // Params (group 2)
+            render_pass.set_bind_group(2, &self.params_uniform.bind_group, &[]);
+            // Resolution (group 3)
+            render_pass.set_bind_group(3, &self.base.resolution_uniform.bind_group, &[]);
+            render_pass.draw(0..4, 0..1);
+        }
+        encoder.copy_texture_to_buffer(
+            wgpu::TexelCopyTextureInfo {
+                texture: &capture_texture,
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+            },
+            wgpu::TexelCopyBufferInfo {
+                buffer: &output_buffer,
+                layout: wgpu::TexelCopyBufferLayout {
+                    offset: 0,
+                    bytes_per_row: Some(padded_bytes_per_row),
+                    rows_per_image: Some(settings.height),
+                },
+            },
+            wgpu::Extent3d {
+                width: settings.width,
+                height: settings.height,
+                depth_or_array_layers: 1,
+            },
+        );
+        core.queue.submit(Some(encoder.finish()));
+        let buffer_slice = output_buffer.slice(..);
+        let (tx, rx) = std::sync::mpsc::channel();
+        buffer_slice.map_async(wgpu::MapMode::Read, move |result| {
+            tx.send(result).unwrap();
+        });
+        core.device.poll(wgpu::Maintain::Wait);
+        rx.recv().unwrap().unwrap();
+        let padded_data = buffer_slice.get_mapped_range().to_vec();
+        let mut unpadded_data = Vec::with_capacity((settings.width * settings.height * 4) as usize);
+        for chunk in padded_data.chunks(padded_bytes_per_row as usize) {
+            unpadded_data.extend_from_slice(&chunk[..unpadded_bytes_per_row as usize]);
+        }
+        Ok(unpadded_data)
+    }
+
+    #[allow(unused_mut)]
+    fn save_frame(&self, mut data: Vec<u8>, frame: u32, settings: &ExportSettings) -> Result<(), ExportError> {
+        let frame_path = settings.export_path
+            .join(format!("frame_{:05}.png", frame));
+        
+        if let Some(parent) = frame_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        #[cfg(target_os = "macos")]
+        {
+            for chunk in data.chunks_mut(4) {
+                chunk.swap(0, 2);
+            }
+        }
+        let image = image::ImageBuffer::<image::Rgba<u8>, Vec<u8>>::from_raw(
+            settings.width,
+            settings.height,
+            data
+        ).ok_or_else(|| ImageError::Parameter(
+            image::error::ParameterError::from_kind(
+                image::error::ParameterErrorKind::Generic(
+                    "Failed to create image buffer".to_string()
+                )
+            )
+        ))?;
+        
+        image.save(&frame_path)?;
+        Ok(())
+    }
+
+    fn handle_export(&mut self, core: &Core) {
+        if let Some((frame, time)) = self.base.export_manager.try_get_next_frame() {
+            if let Ok(data) = self.capture_frame(core, time) {
+                let settings = self.base.export_manager.settings();
+                if let Err(e) = self.save_frame(data, frame, settings) {
+                    eprintln!("Error saving frame: {:?}", e);
+                }
+            }
+        } else {
+            self.base.export_manager.complete_export();
+        }
+    }
+}
+impl ShaderManager for SpiralShader {
+    fn init(core: &cuneus::Core) -> Self {
+        let time_bind_group_layout = core.device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            entries: &[wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::FRAGMENT,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Uniform,
+                    has_dynamic_offset: false,
+                    min_binding_size: None,
+                },
+                count: None,
+            }],
+            label: Some("time_bind_group_layout"),
+        });
+        let resolution_bind_group_layout = core.device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            entries: &[wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::FRAGMENT,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Uniform,
+                    has_dynamic_offset: false,
+                    min_binding_size: None,
+                },
+                count: None,
+            }],
+            label: Some("resolution_bind_group_layout"),
+        });
+        let params_bind_group_layout = core.device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            entries: &[wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::FRAGMENT,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Uniform,
+                    has_dynamic_offset: false,
+                    min_binding_size: None,
+                },
+                count: None,
+            }],
+            label: Some("params_bind_group_layout"),
+        });
+        let params_uniform = UniformBinding::new(
+            &core.device,
+            "Params Uniform",
+            ShaderParams {
+                num_segments: 10.0,
+                palette_height: 0.05,
+                samples_x: 20,
+                samples_y: 20,
+                
+                _pad1: 0.0,
+                _pad2: 0.0,
+                _pad3: 0.0,
+                _pad4: 0.0,
+            },
+            &params_bind_group_layout,
+            0,
+        );
+        let texture_bind_group_layout = core.device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            entries: &[
+                wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Texture {
+                        multisampled: false,
+                        sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                        view_dimension: wgpu::TextureViewDimension::D2,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                    count: None,
+                },
+            ],
+            label: Some("texture_bind_group_layout"),
+        });
+        let bind_group_layouts = vec![
+            &texture_bind_group_layout,    // group 0
+            &time_bind_group_layout,       // group 1 
+            &params_bind_group_layout,     // group 2
+            &resolution_bind_group_layout, // group 3
+        ];
+        let vs_module = core.device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("Vertex Shader"),
+            source: wgpu::ShaderSource::Wgsl(include_str!("../../shaders/vertex.wgsl").into()),
+        });
+
+        let fs_module = core.device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("Fragment Shader"),
+            source: wgpu::ShaderSource::Wgsl(include_str!("../../shaders/scenecolor.wgsl").into()),
+        });
+
+        let shader_paths = vec![
+            PathBuf::from("shaders/vertex.wgsl"),
+            PathBuf::from("shaders/scenecolor.wgsl"),
+        ];
+
+        let hot_reload = ShaderHotReload::new(
+            core.device.clone(),
+            shader_paths,
+            vs_module,
+            fs_module,
+        ).expect("Failed to initialize hot reload");
+        let base = BaseShader::new(
+            core,
+            include_str!("../../shaders/vertex.wgsl"),
+            include_str!("../../shaders/scenecolor.wgsl"),
+            &bind_group_layouts,
+            None,
+        );
+        Self {
+            base,
+            params_uniform,
+            hot_reload,
+            texture_bind_group_layout,
+            time_bind_group_layout,
+            resolution_bind_group_layout,
+            params_bind_group_layout,
+        }
+    }
+
+    fn update(&mut self, core: &Core) {
+        if let Some((new_vs, new_fs)) = self.hot_reload.check_and_reload() {
+            println!("Reloading shaders at time: {:.2}s", self.base.start_time.elapsed().as_secs_f32());
+            let pipeline_layout = core.device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some("Render Pipeline Layout"),
+                bind_group_layouts: &[
+                    &self.texture_bind_group_layout,    // group 0
+                    &self.time_bind_group_layout,       // group 1
+                    &self.params_bind_group_layout,     // group 2
+                    &self.resolution_bind_group_layout, // group 3
+                ],
+                push_constant_ranges: &[],
+            });
+            self.base.renderer = Renderer::new(
+                &core.device,
+                new_vs,
+                new_fs,
+                core.config.format,
+                &pipeline_layout,
+                None,
+            );
+        }
+        if self.base.export_manager.is_exporting() {
+            self.handle_export(core);
+        }
+    }
+    fn render(&mut self, core: &Core) -> Result<(), wgpu::SurfaceError> {
+        let output = core.surface.get_current_texture()?;
+        let view = output.texture.create_view(&wgpu::TextureViewDescriptor::default());
+        if self.base.using_video_texture {
+            self.base.update_video_texture(core, &core.queue);
+        }
+        let mut params = self.params_uniform.data;
+        let mut changed = false;
+        let mut should_start_export = false;
+        let mut export_request = self.base.export_manager.get_ui_request();
+        let mut controls_request = self.base.controls.get_ui_request(
+            &self.base.start_time,
+            &core.size
+        );
+        let using_video_texture = self.base.using_video_texture;
+        let video_info = self.base.get_video_info();
+        let full_output = if self.base.key_handler.show_ui {
+            self.base.render_ui(core, |ctx| {
+                egui::Window::new("Scene Color Palette")
+                    .collapsible(true)
+                    .default_size([300.0, 100.0])
+                    .show(ctx, |ui| {
+                        ui.collapsing("Media", |ui: &mut egui::Ui| {
+                            ShaderControls::render_media_panel(
+                                ui,
+                                &mut controls_request,
+                                using_video_texture,
+                                video_info
+                            );
+                        });
+    
+                        ui.separator();
+                        
+                        // Palette Settings
+                        ui.collapsing("Palette Settings", |ui| {
+                            changed |= ui.add(
+                                egui::Slider::new(&mut params.num_segments, 2.0..=30.0)
+                                    .text("Number of Segments")
+                            ).changed();
+                            
+                            changed |= ui.add(
+                                egui::Slider::new(&mut params.palette_height, 0.01..=0.3)
+                                    .text("Palette Height")
+                            ).changed();
+                        });
+                        
+                        // Sampling Settings
+                        ui.collapsing("Sampling Settings", |ui| {
+                            changed |= ui.add(
+                                egui::Slider::new(&mut params.samples_x, 5..=50)
+                                    .text("Horizontal Samples")
+                            ).changed();
+                            
+                            changed |= ui.add(
+                                egui::Slider::new(&mut params.samples_y, 5..=50)
+                                    .text("Vertical Samples")
+                            ).changed();
+                        });
+    
+                        ui.separator();
+                        ShaderControls::render_controls_widget(ui, &mut controls_request);
+                        ui.separator();
+                        should_start_export = ExportManager::render_export_ui_widget(ui, &mut export_request);
+                    });
+            })
+        } else {
+            self.base.render_ui(core, |_ctx| {})
+        };
+        
+        self.base.export_manager.apply_ui_request(export_request);
+        self.base.apply_control_request(controls_request.clone());
+        self.base.handle_video_requests(core, &controls_request);
+        
+        let current_time = self.base.controls.get_time(&self.base.start_time);
+        self.base.time_uniform.data.time = current_time;
+        self.base.time_uniform.update(&core.queue);
+        
+        if changed {
+            self.params_uniform.data = params;
+            self.params_uniform.update(&core.queue);
+        }
+        
+        if should_start_export {
+            self.base.export_manager.start_export();
+        }
+        
+        let mut encoder = core.device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("Render Encoder"),
+        });
+        {
+            let mut render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("Main Render Pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: &view,
+                    resolve_target: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
+            });
+            render_pass.set_pipeline(&self.base.renderer.render_pipeline);
+            render_pass.set_vertex_buffer(0, self.base.renderer.vertex_buffer.slice(..));
+            
+            if self.base.using_video_texture {
+                if let Some(video_manager) = &self.base.video_texture_manager {
+                    render_pass.set_bind_group(0, &video_manager.texture_manager().bind_group, &[]);
+                }
+            } else if let Some(texture_manager) = &self.base.texture_manager {
+                render_pass.set_bind_group(0, &texture_manager.bind_group, &[]);
+            }
+            // Time (group 1)
+            render_pass.set_bind_group(1, &self.base.time_uniform.bind_group, &[]);
+            // Params (group 2)
+            render_pass.set_bind_group(2, &self.params_uniform.bind_group, &[]);
+            // Resolution (group 3)
+            render_pass.set_bind_group(3, &self.base.resolution_uniform.bind_group, &[]);
+            render_pass.draw(0..4, 0..1);
+        }
+        self.base.handle_render_output(core, &view, full_output, &mut encoder);
+        core.queue.submit(Some(encoder.finish()));
+        output.present();
+        Ok(())
+    }
+    fn resize(&mut self, core: &Core) {
+        self.base.update_resolution(&core.queue, core.size);
+    }
+    fn handle_input(&mut self, core: &Core, event: &WindowEvent) -> bool {
+        if self.base.egui_state.on_window_event(core.window(), event).consumed {
+            return true;
+        }
+        if let WindowEvent::KeyboardInput { event, .. } = event {
+            return self.base.key_handler.handle_keyboard_input(core.window(), event);
+        }
+    
+        false
+    }
+}


### PR DESCRIPTION
shader can render the input texture and extracts a color palette via multi-sampling based on the scene. 

I coded this to understand the colors in this illusion (twitter), but it can also be fun to understand the color palettes in some movies (since cuneus now supports videos) :-)

https://x.com/AkiyoshiKitaoka/status/1897437130819035612/photo/1