### PR TITLE
Feat: Pass the spectrum infos of the audio in the video to the GPU for audiovisual shaders

### DIFF
--- a/shaders/audiovis.wgsl
+++ b/shaders/audiovis.wgsl
@@ -18,7 +18,13 @@ struct TimeUniform {
 };
 
 struct Params { 
-    _padding: f32,
+    red_power: f32,
+    green_power: f32,
+    blue_power: f32,
+    green_boost: f32,
+    contrast: f32, 
+    gamma: f32,
+    glow:f32,
 
 }
 

--- a/shaders/audiovis.wgsl
+++ b/shaders/audiovis.wgsl
@@ -1,0 +1,185 @@
+
+//This is an example shader that uses audio data to create a visualizer effect.
+//Currently still TODO.
+@group(0) @binding(0) var tex: texture_2d<f32>;
+@group(0) @binding(1) var tex_sampler: sampler;
+@group(1) @binding(0) var<uniform> u_time: TimeUniform;
+@group(2) @binding(0) var<uniform> params: Params;
+@group(3) @binding(0) var<uniform> u_resolution: ResolutionUniform;
+
+struct ResolutionUniform {
+    dimensions: vec2<f32>,
+    _padding: vec2<f32>,
+    audio_data: array<vec4<f32>, 8>, 
+};
+
+struct TimeUniform {
+    time: f32,
+};
+
+struct Params { 
+    _padding: f32,
+
+}
+
+@fragment
+fn fs_main(@builtin(position) FragCoord: vec4<f32>, @location(0) tex_coords: vec2<f32>) -> @location(0) vec4<f32> {
+    let resolution = u_resolution.dimensions;
+    // Normalized coordinates
+    let uv = tex_coords;
+    // vis colors
+    let backgroundColor = vec3<f32>(0.05, 0.05, 0.1);
+    // Start with background color
+    var finalColor = backgroundColor;
+    // a subtle grid pattern
+    if (fract(uv.x * 20.0) < 0.05 || fract(uv.y * 20.0) < 0.05) {
+        finalColor = mix(finalColor, vec3<f32>(0.2, 0.2, 0.25), 0.2);
+    }
+    //  total audio energy for effects
+    var totalEnergy = 0.0;
+    // We need to access each value in the vec4 array
+    for (var i = 0; i < 8; i++) {
+        totalEnergy += (u_resolution.audio_data[i].x + 
+                        u_resolution.audio_data[i].y + 
+                        u_resolution.audio_data[i].z + 
+                        u_resolution.audio_data[i].w) / 32.0;
+    }
+    // a background pulse based on total energy
+    finalColor *= 1.0 + totalEnergy * 0.5;
+    // ==================
+    // Draw multi-band equalizer
+    // ==================
+    let eqBottom = 0.15;
+    let eqHeight = 0.7;
+    let bandWidth = 1.0 / 34.0;  // 32 bands + small margins
+    let bandSpacing = bandWidth * 0.1;
+    for (var i = 0; i < 32; i++) {
+        // Calculate position for this frequency band
+        let bandX = (f32(i) + 1.0) * bandWidth;
+        // Get the band energy from our packed vec4 array
+        let vecIndex = i / 4;
+        let vecComponent = i % 4;
+        var bandEnergy = 0.0;
+        if (vecComponent == 0) {
+            bandEnergy = u_resolution.audio_data[vecIndex].x;
+        } else if (vecComponent == 1) {
+            bandEnergy = u_resolution.audio_data[vecIndex].y;
+        } else if (vecComponent == 2) {
+            bandEnergy = u_resolution.audio_data[vecIndex].z;
+        } else {
+            bandEnergy = u_resolution.audio_data[vecIndex].w;
+        }
+        
+        let barHeight = bandEnergy * eqHeight;
+        // Draw frequency band bar if we're within its boundaries
+        if (uv.x >= bandX && uv.x < bandX + bandWidth - bandSpacing) {
+            if (uv.y >= eqBottom && uv.y < eqBottom + barHeight) {
+                // Color gradient based on frequency and height
+                let freqT = f32(i) / 32.0;  // 0-1 range for frequency
+                let heightT = (uv.y - eqBottom) / max(barHeight, 0.001);  // 0-1 range for height within bar
+                // Create a color spectrum from red (low) to blue (high) frequencies
+                let baseColor = mix(
+                    mix(
+                        vec3<f32>(0.9, 0.1, 0.1),  // Low/bass (red)
+                        vec3<f32>(0.9, 0.6, 0.1),  // Low-mid (orange)
+                        min(freqT * 3.0, 1.0)
+                    ),
+                    mix(
+                        vec3<f32>(0.1, 0.8, 0.2),  // Mid (green)
+                        vec3<f32>(0.1, 0.2, 0.9),  // High (blue)
+                        (freqT - 0.33) * 1.5
+                    ),
+                    min(max((freqT - 0.1) * 1.5, 0.0), 1.0)
+                );
+                
+                // Add brightness gradient based on height
+                let color = mix(
+                    baseColor * 0.7,             // Darker at bottom
+                    baseColor * 1.3,             // Brighter at top
+                    heightT
+                );
+                
+                // Add animated stripes based on frequency
+                let stripeSpeed = 1.0 + freqT * 3.0;
+                let stripeWidth = 0.1 + bandEnergy * 0.2;
+                if (fract(uv.y * 15.0 - u_time.time * stripeSpeed) < stripeWidth) {
+                    finalColor = color * 1.3;
+                } else {
+                    finalColor = color;
+                }
+                
+                // Add highlight at top of bar
+                if (uv.y > eqBottom + barHeight - 0.01) {
+                    finalColor = mix(finalColor, vec3<f32>(1.0), 0.5);
+                }
+            }
+        }
+    }
+    
+    // ==================
+    // Draw baseline
+    // ==================
+    if (abs(uv.y - eqBottom) < 0.002) {
+        finalColor = vec3<f32>(0.4, 0.4, 0.5);
+    }
+    
+    // ==================
+    // Draw spectrum analyzer at bottom
+    // ==================
+    if (uv.y < 0.08 && uv.y > 0.02) {
+        let specY = 0.05;
+        let specHeight = 0.03;
+        
+        for (var i = 0; i < 32; i++) {
+            let bandX = (f32(i) + 1.0) * bandWidth;
+            let freqT = f32(i) / 32.0;
+            
+            // Get band energy from our packed array
+            let vecIndex = i / 4;
+            let vecComponent = i % 4;
+            
+            var bandEnergy = 0.0;
+            if (vecComponent == 0) {
+                bandEnergy = u_resolution.audio_data[vecIndex].x;
+            } else if (vecComponent == 1) {
+                bandEnergy = u_resolution.audio_data[vecIndex].y;
+            } else if (vecComponent == 2) {
+                bandEnergy = u_resolution.audio_data[vecIndex].z;
+            } else {
+                bandEnergy = u_resolution.audio_data[vecIndex].w;
+            }
+            
+            // Calculate peak height
+            let peakHeight = bandEnergy * specHeight;
+            
+            // Draw peak line
+            if (uv.x >= bandX && uv.x < bandX + bandWidth - bandSpacing) {
+                // Draw frequency band
+                if (uv.y >= specY - peakHeight && uv.y <= specY) {
+                    // Color based on frequency
+                    let color = mix(
+                        vec3<f32>(1.0, 0.2, 0.1),  // Low/bass (red)
+                        mix(
+                            vec3<f32>(1.0, 0.8, 0.1),  // Mid (yellow)
+                            vec3<f32>(0.2, 0.4, 1.0),  // High (blue)
+                            min(max((freqT - 0.3) * 1.5, 0.0), 1.0)
+                        ),
+                        min(freqT * 2.0, 1.0)
+                    );
+                    
+                    finalColor = color;
+                }
+            }
+        }
+        
+        // Draw baseline for spectrum
+        if (abs(uv.y - specY) < 0.001) {
+            finalColor = vec3<f32>(0.3, 0.3, 0.3);
+        }
+    }
+    
+    // Get alpha from original texture
+    let alpha = textureSample(tex, tex_sampler, uv).a;
+    
+    return vec4<f32>(finalColor, alpha);
+}

--- a/src/base_shader.rs
+++ b/src/base_shader.rs
@@ -459,105 +459,114 @@ impl BaseShader {
                     
                     if !spectrum_data.magnitudes.is_empty() {
                         let bands = spectrum_data.bands;
-                        let threshold: f32 = -75.0;
-                        // First, store raw audio data with minimal processing
+                        // Highly sensitive threshold for detecting subtle high frequencies
+                        let threshold: f32 = -60.0;
+                        // Store raw audio data with frequency-dependent processing
                         for i in 0..128.min(bands) {
-                            // Simple linear mapping
-                            let src_idx = (i as f32 / 128.0 * bands as f32) as usize;
+                            // Linear frequency index for accurate frequency representation
+                            let band_percent = i as f32 / 128.0;
+                            // Map to source index with slight emphasis on higher frequencies
+                            let src_idx = (band_percent * (0.8 + band_percent * 0.2) * bands as f32) as usize;
                             if src_idx < bands {
                                 // Get value
                                 let val = spectrum_data.magnitudes[src_idx];
+                                // Normalize from dB to 0-1 with frequency-dependent boost
+                                // Higher frequencies get progressively more boost
+                                let freq_boost = if band_percent < 0.6 {
+                                    // No boost for low/mid frequencies
+                                    1.0
+                                } else {
+                                    // Progressive boost for high frequencies
+                                    // Linear increase from 1.0 at 60% to 4.0 at 100%
+                                    1.0 + (band_percent - 0.6) * 7.5
+                                };
                                 
-                                // Simple normalization from dB to 0-1
-                                let normalized = ((val - threshold) / -threshold)
-                                    .max(0.0).min(1.0);
-                                
+                                // Basic normalization
+                                let normalized = ((val - threshold) / -threshold).max(0.0).min(1.0);
+                                // Apply frequency boost with limiting
+                                let boosted = (normalized * freq_boost).min(1.0);
                                 // Store in raw audio array
                                 let vec_idx = i / 4;
                                 let vec_component = i % 4;
-                                
                                 if vec_idx < 32 {
-                                    self.resolution_uniform.data.audio_raw[vec_idx][vec_component] = normalized;
+                                    self.resolution_uniform.data.audio_raw[vec_idx][vec_component] = boosted;
                                 }
                             }
                         }
-                        
-                        // process audio with enhancements (audio_data)
+                        // Process enhanced audio data with accurate representation
                         for i in 0..128.min(bands) {
-                            // linear mapping
-                            let source_idx = (i as f32 / 128.0 * bands as f32) as usize;
-                            // Narrower widths for all bands
+                            let band_percent = i as f32 / 128.0;
+                            // Similar conservative mapping as above
+                            let source_idx = (band_percent * (0.8 + band_percent * 0.2) * bands as f32) as usize;
+                            // Use narrow width for all frequencies for accuracy
                             let width = 1;
-                            
                             let end_idx = (source_idx + width).min(bands);
                             if source_idx < bands {
-                                // Get peak value in this small range
+                                // Get peak value in this range
                                 let mut peak: f32 = -120.0;
-                                
                                 for j in source_idx..end_idx {
                                     if j < bands {
                                         let val = spectrum_data.magnitudes[j];
                                         peak = peak.max(val);
                                     }
                                 }
-                                
                                 // Map from dB scale to 0-1
-                                let normalized = ((peak - threshold) / -threshold)
-                                    .max(0.0).min(1.0);
-                                
-                                // Apply frequency-specific enhancements with stronger reductions for highs
-                                let band_percent = i as f32 / 128.0;
-                                let enhanced = if band_percent < 0.125 {
-                                    (normalized.powf(0.5) * 1.3).min(1.0)
-                                } else if band_percent < 0.25 {
-                                    // Bass
-                                    (normalized.powf(0.55) * 1.2).min(1.0)
-                                } else if band_percent < 0.5 {
-                                    // Lower-mids
-                                    (normalized.powf(0.6) * 1.1).min(1.0)
-                                } else if band_percent < 0.75 {
-                                    // Upper-mids
-                                    (normalized.powf(0.65) * 0.9).min(1.0)
+                                let normalized = ((peak - threshold) / -threshold).max(0.0).min(1.0);
+                                // Apply frequency-specific processing that's balanced
+                                // Lower boost for bass, higher boost for treble
+                                let enhanced = if band_percent < 0.2 {
+                                    // Bass - slightly reduced
+                                    (normalized.powf(0.75) * 0.85).min(1.0)
+                                } else if band_percent < 0.4 {
+                                    // Low-mids - neutral
+                                    normalized.powf(0.7).min(1.0)
+                                } else if band_percent < 0.6 {
+                                    // Mids - slight boost
+                                    (normalized.powf(0.65) * 1.1).min(1.0)
+                                } else if band_percent < 0.8 {
+                                    // Upper-mids - moderate boost
+                                    (normalized.powf(0.55) * 1.6).min(1.0)
                                 } else {
-                                    // Highs
-                                    (normalized.powf(0.7) * 0.7).min(1.0)
+                                    // Highs - significant boost with lower power
+                                    // The critical adjustment for high frequency sensitivity
+                                    (normalized.powf(0.4) * 3.0).min(1.0)
                                 };
-                                // minimal hf
-                                let thresholded = if band_percent >= 0.8 && enhanced < 0.2 {
-                                    0.0 
-                                } else {
-                                    enhanced
-                                };
-                                
-                                // Temporal smoothing
+                                // No minimum thresholds - let silent frequencies be silent
+                                // Temporal smoothing with frequency-specific parameters
                                 let vec_idx = i / 4;
                                 let vec_component = i % 4;
                                 if vec_idx < 32 {
                                     let prev_value = self.prev_audio_data[vec_idx][vec_component];
-                                    
-                                    // Adaptive smoothing - fast attack, slow decay
-                                    let smoothing_factor = if thresholded > prev_value {
-                                        // Fast attack (quick rise)
-                                        0.6
+                                    // Fast attack for all frequencies - slightly faster for highs
+                                    let attack = if band_percent < 0.6 {
+                                        0.6 
                                     } else {
-                                        // Slow decay (gradual fall) 
-                                        0.3
+                                        0.7 
+                                    };
+                                    let decay = if band_percent < 0.6 {
+                                        0.3 
+                                    } else {
+                                        0.25 
                                     };
                                     
                                     // Apply smoothing
+                                    let smoothing_factor = if enhanced > prev_value {
+                                        attack  // Rising
+                                    } else {
+                                        decay   // Falling
+                                    };
+                                    // Calculate smoothed value
                                     let smoothed = prev_value * (1.0 - smoothing_factor) + 
-                                                  thresholded * smoothing_factor;
-                                    
+                                                  enhanced * smoothing_factor;
                                     // Store the result
                                     self.resolution_uniform.data.audio_data[vec_idx][vec_component] = smoothed;
-                                    
-                                    // Store current value for next frame
+                                    // Store for next frame
                                     self.prev_audio_data[vec_idx][vec_component] = smoothed;
                                 }
                             }
                         }
                         
-                        // Apply beat detection boost
+                        // Beat detection with balanced boost across frequency spectrum
                         let mut bass_energy: f32 = 0.0;
                         let bass_bands = 128 / 16;
                         for i in 0..(bass_bands / 4) {
@@ -567,23 +576,30 @@ impl BaseShader {
                         }
                         bass_energy /= bass_bands as f32;
                         
-                        // If we detect a beat, boost all bands
-                        if bass_energy > 0.6 {
-                            // First quarter - strongest boost (bass)
+                        // If we detect a beat, provide progressive boost to mid/high frequencies
+                        if bass_energy > 0.5 {
+                            // First quarter - bass 
                             let q1 = 32 / 4;
-                            // Second quarter - medium boost (low-mids)
+                            // Second quarter - low-mids
                             let q2 = 32 / 2;
+                            // Third quarter - upper-mids
+                            let q3 = 3 * 32 / 4;
+                            
                             for i in 0..32 {
                                 for j in 0..4 {
                                     if i < q1 {
-                                        // Strong boost for bass
-                                        self.resolution_uniform.data.audio_data[i][j] *= 1.2;
+                                        // No boost for bass (prevent dominance)
+                                        // Actually reduce bass slightly on beats
+                                        self.resolution_uniform.data.audio_data[i][j] *= 0.9;
                                     } else if i < q2 {
-                                        // Medium boost for low-mids
-                                        self.resolution_uniform.data.audio_data[i][j] *= 1.2;
+                                        // Small boost for low-mids
+                                        self.resolution_uniform.data.audio_data[i][j] *= 1.1;
+                                    } else if i < q3 {
+                                        // Moderate boost for upper-mids
+                                        self.resolution_uniform.data.audio_data[i][j] *= 1.3;
                                     } else {
-                                        // Slight boost for highs
-                                        self.resolution_uniform.data.audio_data[i][j] *= 1.15;
+                                        // Strong boost for highs during beats
+                                        self.resolution_uniform.data.audio_data[i][j] *= 1.7;
                                     }
                                 }
                             }

--- a/src/bin/audiovis.rs
+++ b/src/bin/audiovis.rs
@@ -20,10 +20,12 @@ impl UniformProvider for ShaderParams {
     }
 }
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    //debugs  are active untill I merge the PR
     cuneus::gst::init()?;
     std::env::set_var("RUST_LOG", "info,gstreamer=debug,cuneus=debug");
     env_logger::init();
-    std::env::set_var("GST_DEBUG", "spectrum:5");
+    std::env::set_var("GST_DEBUG", "bpmdetect:5,pitch:5,soundtouch:5,bus:4,element:4");
+
     let (app, event_loop) = ShaderApp::new("audiovis", 800, 600);
     let shader = AudioVis::init(app.core());
     app.run(event_loop, shader)

--- a/src/bin/audiovis.rs
+++ b/src/bin/audiovis.rs
@@ -5,7 +5,13 @@ use std::path::PathBuf;
 #[repr(C)]
 #[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
 struct ShaderParams {
- _padding:f32
+    red_power: f32,
+    green_power: f32,
+    blue_power: f32,
+    green_boost: f32,
+    contrast: f32,
+    gamma: f32,
+    glow:f32,
 }
 
 impl UniformProvider for ShaderParams {
@@ -207,7 +213,13 @@ impl ShaderManager for AudioVis {
             &core.device,
             "Params Uniform",
             ShaderParams {
-                _padding: 0.0
+                red_power: 0.98,
+                green_power: 0.85,
+                blue_power: 0.90,
+                green_boost: 1.62,
+                contrast: 1.0,
+                gamma: 1.0,
+                glow: 0.05,
 
             },
             &params_bind_group_layout,
@@ -253,7 +265,7 @@ impl ShaderManager for AudioVis {
 
         let shader_paths = vec![
             PathBuf::from("shaders/vertex.wgsl"),
-            PathBuf::from("shaders/matrix.wgsl"),
+            PathBuf::from("shaders/audiovis.wgsl"),
         ];
 
         let hot_reload = ShaderHotReload::new(
@@ -265,7 +277,7 @@ impl ShaderManager for AudioVis {
         let base = BaseShader::new(
             core,
             include_str!("../../shaders/vertex.wgsl"),
-            include_str!("../../shaders/matrix.wgsl"),
+            include_str!("../../shaders/audiovis.wgsl"),
             &bind_group_layouts,
             None,
         );

--- a/src/bin/audiovis.rs
+++ b/src/bin/audiovis.rs
@@ -1,0 +1,418 @@
+use cuneus::{Core,Renderer,ShaderApp, ShaderManager, UniformProvider, UniformBinding, BaseShader,ExportSettings, ExportError, ExportManager,ShaderHotReload,ShaderControls};
+use winit::event::*;
+use image::ImageError;
+use std::path::PathBuf;
+#[repr(C)]
+#[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
+struct ShaderParams {
+ _padding:f32
+}
+
+impl UniformProvider for ShaderParams {
+    fn as_bytes(&self) -> &[u8] {
+        bytemuck::bytes_of(self)
+    }
+}
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    cuneus::gst::init()?;
+    std::env::set_var("RUST_LOG", "info,gstreamer=debug,cuneus=debug");
+    env_logger::init();
+    std::env::set_var("GST_DEBUG", "spectrum:5");
+    let (app, event_loop) = ShaderApp::new("audiovis", 800, 600);
+    let shader = AudioVis::init(app.core());
+    app.run(event_loop, shader)
+}
+struct AudioVis {
+    base: BaseShader,
+    params_uniform: UniformBinding<ShaderParams>,
+    hot_reload: ShaderHotReload,
+    texture_bind_group_layout: wgpu::BindGroupLayout,
+    time_bind_group_layout: wgpu::BindGroupLayout,
+    resolution_bind_group_layout: wgpu::BindGroupLayout,
+    params_bind_group_layout: wgpu::BindGroupLayout,
+}
+impl AudioVis {
+
+    fn capture_frame(&mut self, core: &Core, time: f32) -> Result<Vec<u8>, wgpu::SurfaceError> {
+        let settings = self.base.export_manager.settings();
+        let (capture_texture, output_buffer) = self.base.create_capture_texture(
+            &core.device,
+            settings.width,
+            settings.height
+        );
+        let align = 256;
+        let unpadded_bytes_per_row = settings.width * 4;
+        let padding = (align - unpadded_bytes_per_row % align) % align;
+        let padded_bytes_per_row = unpadded_bytes_per_row + padding;
+        let capture_view = capture_texture.create_view(&wgpu::TextureViewDescriptor::default());
+        let mut encoder = core.device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("Capture Encoder"),
+        });
+        self.base.time_uniform.data.time = time;
+        self.base.time_uniform.update(&core.queue);
+        self.base.resolution_uniform.data.dimensions = [settings.width as f32, settings.height as f32];
+        self.base.resolution_uniform.update(&core.queue);
+        {
+            let mut render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("Capture Pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: &capture_view,
+                    resolve_target: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
+            });
+            render_pass.set_pipeline(&self.base.renderer.render_pipeline);
+            render_pass.set_vertex_buffer(0, self.base.renderer.vertex_buffer.slice(..));
+            if self.base.using_video_texture {
+                if let Some(video_manager) = &self.base.video_texture_manager {
+                    render_pass.set_bind_group(0, &video_manager.texture_manager().bind_group, &[]);
+                }
+            } else if let Some(texture_manager) = &self.base.texture_manager {
+                render_pass.set_bind_group(0, &texture_manager.bind_group, &[]);
+            }
+            render_pass.set_bind_group(1, &self.base.time_uniform.bind_group, &[]);
+            render_pass.set_bind_group(2, &self.params_uniform.bind_group, &[]);
+            render_pass.set_bind_group(3, &self.base.resolution_uniform.bind_group, &[]);
+            render_pass.draw(0..4, 0..1);
+        }
+        encoder.copy_texture_to_buffer(
+            wgpu::TexelCopyTextureInfo {
+                texture: &capture_texture,
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+            },
+            wgpu::TexelCopyBufferInfo {
+                buffer: &output_buffer,
+                layout: wgpu::TexelCopyBufferLayout {
+                    offset: 0,
+                    bytes_per_row: Some(padded_bytes_per_row),
+                    rows_per_image: Some(settings.height),
+                },
+            },
+            wgpu::Extent3d {
+                width: settings.width,
+                height: settings.height,
+                depth_or_array_layers: 1,
+            },
+        );
+        core.queue.submit(Some(encoder.finish()));
+        let buffer_slice = output_buffer.slice(..);
+        let (tx, rx) = std::sync::mpsc::channel();
+        buffer_slice.map_async(wgpu::MapMode::Read, move |result| {
+            tx.send(result).unwrap();
+        });
+        core.device.poll(wgpu::Maintain::Wait);
+        rx.recv().unwrap().unwrap();
+        let padded_data = buffer_slice.get_mapped_range().to_vec();
+        let mut unpadded_data = Vec::with_capacity((settings.width * settings.height * 4) as usize);
+        for chunk in padded_data.chunks(padded_bytes_per_row as usize) {
+            unpadded_data.extend_from_slice(&chunk[..unpadded_bytes_per_row as usize]);
+        }
+        Ok(unpadded_data)
+    }
+
+    #[allow(unused_mut)]
+    fn save_frame(&self, mut data: Vec<u8>, frame: u32, settings: &ExportSettings) -> Result<(), ExportError> {
+        let frame_path = settings.export_path
+            .join(format!("frame_{:05}.png", frame));
+        
+        if let Some(parent) = frame_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        #[cfg(target_os = "macos")]
+        {
+            for chunk in data.chunks_mut(4) {
+                chunk.swap(0, 2);
+            }
+        }
+        let image = image::ImageBuffer::<image::Rgba<u8>, Vec<u8>>::from_raw(
+            settings.width,
+            settings.height,
+            data
+        ).ok_or_else(|| ImageError::Parameter(
+            image::error::ParameterError::from_kind(
+                image::error::ParameterErrorKind::Generic(
+                    "Failed to create image buffer".to_string()
+                )
+            )
+        ))?;
+        
+        image.save(&frame_path)?;
+        Ok(())
+    }
+
+    fn handle_export(&mut self, core: &Core) {
+        if let Some((frame, time)) = self.base.export_manager.try_get_next_frame() {
+            if let Ok(data) = self.capture_frame(core, time) {
+                let settings = self.base.export_manager.settings();
+                if let Err(e) = self.save_frame(data, frame, settings) {
+                    eprintln!("Error saving frame: {:?}", e);
+                }
+            }
+        } else {
+            self.base.export_manager.complete_export();
+        }
+    }
+}
+impl ShaderManager for AudioVis {
+    fn init(core: &cuneus::Core) -> Self {
+        let time_bind_group_layout = core.device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            entries: &[wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::FRAGMENT,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Uniform,
+                    has_dynamic_offset: false,
+                    min_binding_size: None,
+                },
+                count: None,
+            }],
+            label: Some("time_bind_group_layout"),
+        });
+        let resolution_bind_group_layout = core.device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            entries: &[wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::FRAGMENT,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Uniform,
+                    has_dynamic_offset: false,
+                    min_binding_size: None,
+                },
+                count: None,
+            }],
+            label: Some("resolution_bind_group_layout"),
+        });
+        let params_bind_group_layout = core.device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            entries: &[wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::FRAGMENT,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Uniform,
+                    has_dynamic_offset: false,
+                    min_binding_size: None,
+                },
+                count: None,
+            }],
+            label: Some("params_bind_group_layout"),
+        });
+        
+        let params_uniform = UniformBinding::new(
+            &core.device,
+            "Params Uniform",
+            ShaderParams {
+                _padding: 0.0
+
+            },
+            &params_bind_group_layout,
+            0,
+        );
+        
+        let texture_bind_group_layout = core.device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            entries: &[
+                wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Texture {
+                        multisampled: false,
+                        sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                        view_dimension: wgpu::TextureViewDimension::D2,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                    count: None,
+                },
+            ],
+            label: Some("texture_bind_group_layout"),
+        });
+        let bind_group_layouts = vec![
+            &texture_bind_group_layout,
+            &time_bind_group_layout,
+            &params_bind_group_layout,
+            &resolution_bind_group_layout,
+        ];
+        let vs_module = core.device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("Vertex Shader"),
+            source: wgpu::ShaderSource::Wgsl(include_str!("../../shaders/vertex.wgsl").into()),
+        });
+
+        let fs_module = core.device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("Fragment Shader"),
+            source: wgpu::ShaderSource::Wgsl(include_str!("../../shaders/audiovis.wgsl").into()),
+        });
+
+        let shader_paths = vec![
+            PathBuf::from("shaders/vertex.wgsl"),
+            PathBuf::from("shaders/matrix.wgsl"),
+        ];
+
+        let hot_reload = ShaderHotReload::new(
+            core.device.clone(),
+            shader_paths,
+            vs_module,
+            fs_module,
+        ).expect("Failed to initialize hot reload");
+        let base = BaseShader::new(
+            core,
+            include_str!("../../shaders/vertex.wgsl"),
+            include_str!("../../shaders/matrix.wgsl"),
+            &bind_group_layouts,
+            None,
+        );
+        Self {
+            base,
+            params_uniform,
+            hot_reload,
+            texture_bind_group_layout,
+            time_bind_group_layout,
+            resolution_bind_group_layout,
+            params_bind_group_layout,
+        }
+    }
+
+    fn update(&mut self, core: &Core) {
+        if let Some((new_vs, new_fs)) = self.hot_reload.check_and_reload() {
+            println!("Reloading shaders at time: {:.2}s", self.base.start_time.elapsed().as_secs_f32());
+            let pipeline_layout = core.device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some("Render Pipeline Layout"),
+                bind_group_layouts: &[
+                    &self.texture_bind_group_layout,
+                    &self.time_bind_group_layout,
+                    &self.params_bind_group_layout,
+                    &self.resolution_bind_group_layout,
+                ],
+                push_constant_ranges: &[],
+            });
+            self.base.renderer = Renderer::new(
+                &core.device,
+                new_vs,
+                new_fs,
+                core.config.format,
+                &pipeline_layout,
+                None,
+            );
+        }
+        if self.base.export_manager.is_exporting() {
+            self.handle_export(core);
+        }
+    }
+    
+    fn render(&mut self, core: &Core) -> Result<(), wgpu::SurfaceError> {
+        let output = core.surface.get_current_texture()?;
+        let view = output.texture.create_view(&wgpu::TextureViewDescriptor::default());
+        if self.base.using_video_texture {
+            self.base.update_video_texture(core, &core.queue);
+        }
+        let mut should_start_export = false;
+        let mut export_request = self.base.export_manager.get_ui_request();
+        let mut controls_request = self.base.controls.get_ui_request(
+            &self.base.start_time,
+            &core.size
+        );
+        let using_video_texture = self.base.using_video_texture;
+        let video_info = self.base.get_video_info();
+        let full_output = if self.base.key_handler.show_ui {
+            self.base.render_ui(core, |ctx| {
+                egui::Window::new("vis")
+                    .collapsible(true)
+                    .default_size([300.0, 100.0])
+                    .show(ctx, |ui| {
+                        ui.collapsing("Media", |ui: &mut egui::Ui| {
+                            ShaderControls::render_media_panel(
+                                ui,
+                                &mut controls_request,
+                                using_video_texture,
+                                video_info
+                            );
+                        });
+    
+                        ui.separator();
+                        ui.separator();
+                        ShaderControls::render_controls_widget(ui, &mut controls_request);
+                        ui.separator();
+                        should_start_export = ExportManager::render_export_ui_widget(ui, &mut export_request);
+                    });
+            })
+        } else {
+            self.base.render_ui(core, |_ctx| {})
+        };
+        
+        self.base.export_manager.apply_ui_request(export_request);
+        self.base.apply_control_request(controls_request.clone());
+        self.base.handle_video_requests(core, &controls_request);
+        
+        let current_time = self.base.controls.get_time(&self.base.start_time);
+        self.base.time_uniform.data.time = current_time;
+        self.base.time_uniform.update(&core.queue);
+        self.base.update_audio_spectrum(&core.queue);
+
+
+        
+        if should_start_export {
+            self.base.export_manager.start_export();
+        }
+        
+        let mut encoder = core.device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("Render Encoder"),
+        });
+        {
+            let mut render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("Main Render Pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: &view,
+                    resolve_target: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
+            });
+            render_pass.set_pipeline(&self.base.renderer.render_pipeline);
+            render_pass.set_vertex_buffer(0, self.base.renderer.vertex_buffer.slice(..));
+            
+            if self.base.using_video_texture {
+                if let Some(video_manager) = &self.base.video_texture_manager {
+                    render_pass.set_bind_group(0, &video_manager.texture_manager().bind_group, &[]);
+                }
+            } else if let Some(texture_manager) = &self.base.texture_manager {
+                render_pass.set_bind_group(0, &texture_manager.bind_group, &[]);
+            }
+            render_pass.set_bind_group(1, &self.base.time_uniform.bind_group, &[]);
+            render_pass.set_bind_group(2, &self.params_uniform.bind_group, &[]);
+            render_pass.set_bind_group(3, &self.base.resolution_uniform.bind_group, &[]);
+            render_pass.draw(0..4, 0..1);
+        }
+        self.base.handle_render_output(core, &view, full_output, &mut encoder);
+        core.queue.submit(Some(encoder.finish()));
+        output.present();
+        Ok(())
+    }
+    
+    fn resize(&mut self, core: &Core) {
+        self.base.update_resolution(&core.queue, core.size);
+    }
+    
+    fn handle_input(&mut self, core: &Core, event: &WindowEvent) -> bool {
+        if self.base.egui_state.on_window_event(core.window(), event).consumed {
+            return true;
+        }
+        if let WindowEvent::KeyboardInput { event, .. } = event {
+            return self.base.key_handler.handle_keyboard_input(core.window(), event);
+        }
+    
+        false
+    }
+}

--- a/src/gst/mod.rs
+++ b/src/gst/mod.rs
@@ -3,9 +3,8 @@ pub mod video;
 use log::info;
 
 pub fn init() -> anyhow::Result<()> {
-    // Set very verbose logging for spectrum and element messages
-    std::env::set_var("RUST_LOG", "info,warn,debug,gstreamer=debug,cuneus=debug,spectrum=trace");
-    std::env::set_var("GST_DEBUG", "spectrum:5,bus:5,message:5");
+    // These are active untill I merge the PR
+    std::env::set_var("GST_DEBUG", "bpmdetect:5,pitch:5,soundtouch:5,bus:4,element:4");
     info!("Setting up GStreamer with enhanced logging");
     gstreamer::init()?;
     info!("GStreamer initialized successfully");

--- a/src/gst/mod.rs
+++ b/src/gst/mod.rs
@@ -3,7 +3,10 @@ pub mod video;
 use log::info;
 
 pub fn init() -> anyhow::Result<()> {
-    info!("Initializing GStreamer subsystem");
+    // Set very verbose logging for spectrum and element messages
+    std::env::set_var("RUST_LOG", "info,warn,debug,gstreamer=debug,cuneus=debug,spectrum=trace");
+    std::env::set_var("GST_DEBUG", "spectrum:5,bus:5,message:5");
+    info!("Setting up GStreamer with enhanced logging");
     gstreamer::init()?;
     info!("GStreamer initialized successfully");
     Ok(())

--- a/src/gst/video.rs
+++ b/src/gst/video.rs
@@ -347,7 +347,7 @@ impl VideoTextureManager {
                             .property("post-messages", true)
                             .property("message-magnitude", true)
                             .property("message-phase", false)
-                            .property("interval", 10000000u64) 
+                            .property("interval", 50000000u64) 
                             .build() {
                                 Ok(e) => {
                                     info!("Created spectrum analyzer with {} bands and threshold {}dB", 

--- a/src/gst/video.rs
+++ b/src/gst/video.rs
@@ -7,8 +7,33 @@ use std::path::Path;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 use gst::prelude::*;
+use gst::glib::ControlFlow;
 use crate::texture::TextureManager;
 use wgpu;
+
+#[derive(Debug, Clone)]
+pub struct SpectrumData {
+    /// Number of frequency bands
+    pub bands: usize,
+    /// Magnitude values for each frequency band in dB
+    pub magnitudes: Vec<f32>,
+    /// Phase values for each frequency band
+    pub phases: Option<Vec<f32>>,
+    /// Timestamp of the spectrum data
+    pub timestamp: Option<gst::ClockTime>,
+}
+
+impl Default for SpectrumData {
+    fn default() -> Self {
+        Self {
+            bands: 0,
+            magnitudes: Vec::new(),
+            phases: None,
+            timestamp: None,
+        }
+    }
+}
+
 /// Here I created a struct to organize the video text mang.
 /// Manages a video texture that can be updated frame by frame
 pub struct VideoTextureManager {
@@ -45,7 +70,16 @@ pub struct VideoTextureManager {
     texture_initialized: bool,
     /// Frame counter for debugging
     frame_count: usize,
+    /// Spectrum analysis enabled
+    spectrum_enabled: bool,
+    /// Number of frequency bands for spectrum analysis
+    spectrum_bands: usize,
+    /// Threshold in dB for spectrum analysis
+    spectrum_threshold: i32,
+    /// Spectrum data from the most recent analysis
+    spectrum_data: Arc<Mutex<SpectrumData>>,
 }
+
 impl VideoTextureManager {
     pub fn new(
         device: &wgpu::Device,
@@ -138,6 +172,118 @@ impl VideoTextureManager {
         // now audio elements reference holders
         let audioconvert_weak = Arc::new(Mutex::new(None));
         
+        // Default spectrum configuration
+        let spectrum_bands = 128;
+        let spectrum_threshold = -60;
+        let spectrum_enabled = true;
+        let spectrum_data = Arc::new(Mutex::new(SpectrumData::default()));
+        
+        // bus watch for spectrum messages with debug
+        let bus = pipeline.bus().expect("Pipeline has no bus");
+        let spectrum_data_clone2 = spectrum_data.clone();
+        
+        // message handler for spectrum messages (these are my sanity checks)
+        let _ = bus.add_watch(move |_, message| {
+            // Log ALL message types
+            info!("Bus message received: type={:?}", message.type_());
+            
+            // Print source information
+            if let Some(src) = message.src() {
+                info!("Message source: {}", src.name());
+            }
+            
+            match message.view() {
+                gst::MessageView::Element(element) => {
+                    if let Some(structure) = element.structure() {
+                        info!("Element message structure name: '{}'", structure.name());
+                        
+                        // Explicitly check for spectrum messages
+                        if structure.name() == "spectrum" {
+                            info!("SPECTRUM MESSAGE DETECTED ");
+                            info!("Full structure: {}", structure.to_string());
+                            
+                            // Try ALL possible ways to extract spectrum data
+                            let mut magnitude_values = Vec::new();
+                            
+                            // Method 1: Direct indexing
+                            for i in 0..5 {  // Just try first 5 bands initially
+                                let field_name = format!("magnitude[{}]", i);
+                                match structure.get::<f32>(&field_name) {
+                                    Ok(value) => {
+                                        info!("✅ Method 1 - Band {}: {} dB", i, value);
+                                        magnitude_values.push(value);
+                                    },
+                                    Err(e) => {
+                                        info!("❌ Method 1 failed: {:?}", e);
+                                        break;
+                                    }
+                                }
+                            }
+                            
+                            // Method 2: Try to access magnitude as array field
+                            if structure.has_field("magnitude") {
+                                info!("✅ Structure has 'magnitude' field");
+                            } else {
+                                info!("❌ Structure does NOT have 'magnitude' field");
+                            }
+                            
+                            // Method 3: Parse from structure string
+                            let struct_str = structure.to_string();
+                            info!("Structure string: {}", struct_str);
+                            
+                            // If we found magnitude values through any method, process them
+                            if !magnitude_values.is_empty() {
+                                // Continue extracting all magnitude values
+                                let mut i = magnitude_values.len();
+                                loop {
+                                    let field_name = format!("magnitude[{}]", i);
+                                    if let Ok(value) = structure.get::<f32>(&field_name) {
+                                        magnitude_values.push(value);
+                                        i += 1;
+                                    } else {
+                                        break;
+                                    }
+                                }
+                                
+                                // Log summary of extracted data
+                                info!("Extracted {} magnitude values", magnitude_values.len());
+                                
+                                // Calculate average magnitude
+                                let avg_magnitude = magnitude_values.iter().sum::<f32>() / magnitude_values.len() as f32;
+                                info!("Average magnitude: {:.2} dB", avg_magnitude);
+                                
+                                // Find peak frequency
+                                if let Some((peak_idx, &peak_val)) = magnitude_values.iter()
+                                    .enumerate()
+                                    .max_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal)) 
+                                {
+                                    info!("Peak frequency: band {} at {:.2} dB", peak_idx, peak_val);
+                                }
+                                
+                                // Update spectrum data
+                                if let Ok(mut data) = spectrum_data_clone2.lock() {
+                                    *data = SpectrumData {
+                                        bands: magnitude_values.len(),
+                                        magnitudes: magnitude_values,
+                                        phases: None,
+                                        timestamp: structure.get("timestamp").ok(),
+                                    };
+                                }
+                            } else {
+                                warn!("⚠️ Failed to extract any magnitude values from spectrum message");
+                            }
+                        }
+                    }
+                },
+                gst::MessageView::Error(err) => {
+                    error!("Pipeline error: {} ({})", err.error(), err.debug().unwrap_or_default());
+                },
+                _ => (),
+            }
+            
+            ControlFlow::Continue
+        }).map_err(|_| anyhow!("Failed to add bus watch"));
+        
         decodebin.connect_pad_added(move |_, pad| {
             let caps = match pad.current_caps() {
                 Some(caps) => caps,
@@ -193,7 +339,26 @@ impl VideoTextureManager {
                                     return;
                                 }
                             };
-                            
+
+                        let spectrum = match gst::ElementFactory::make("spectrum")
+                            .name("spectrum")
+                            .property("bands", spectrum_bands as u32)
+                            .property("threshold", spectrum_threshold)
+                            .property("post-messages", true)
+                            .property("message-magnitude", true)
+                            .property("message-phase", false)
+                            .property("interval", 10000000u64) 
+                            .build() {
+                                Ok(e) => {
+                                    info!("Created spectrum analyzer with {} bands and threshold {}dB", 
+                                         spectrum_bands, spectrum_threshold);
+                                    e
+                                },
+                                Err(_) => {
+                                    warn!("Failed to create spectrum analyzer");
+                                    return;
+                                }
+                            };
                         let volume = match gst::ElementFactory::make("volume")
                             .name("volume")
                             .property("volume", 1.0)
@@ -219,13 +384,13 @@ impl VideoTextureManager {
                         // Add elements to pipeline
                         if let Err(e) = pad.parent_element().unwrap().parent().unwrap()
                                          .downcast_ref::<gst::Pipeline>().unwrap()
-                                         .add_many(&[&audioconvert, &audioresample, &volume, &audio_sink]) {
+                                         .add_many(&[&audioconvert, &audioresample, &spectrum, &volume, &audio_sink]) {
                             warn!("Failed to add audio elements: {:?}", e);
                             return;
                         }
                         
                         // Link audio elements
-                        if let Err(e) = gst::Element::link_many(&[&audioconvert, &audioresample, &volume, &audio_sink]) {
+                        if let Err(e) = gst::Element::link_many(&[&audioconvert, &audioresample, &spectrum, &volume, &audio_sink]) {
                             warn!("Failed to link audio elements: {:?}", e);
                             return;
                         }
@@ -233,6 +398,7 @@ impl VideoTextureManager {
                         // Set elements to PAUSED state
                         let _ = audioconvert.sync_state_with_parent();
                         let _ = audioresample.sync_state_with_parent();
+                        let _ = spectrum.sync_state_with_parent();
                         let _ = volume.sync_state_with_parent();
                         let _ = audio_sink.sync_state_with_parent();
                         
@@ -353,6 +519,10 @@ impl VideoTextureManager {
             video_path: path_str,
             texture_initialized: false,
             frame_count: 0,
+            spectrum_enabled,
+            spectrum_bands,
+            spectrum_threshold,
+            spectrum_data,
         };
         // Start pipeline in paused state to get video info
         if video_texture.pipeline.set_state(gst::State::Paused).is_err() {
@@ -454,7 +624,124 @@ impl VideoTextureManager {
                 debug!("Processing video frame #{} (dimensions: {}x{})", 
                      self.frame_count, width, height);
             }
-            
+            if self.has_audio && self.spectrum_enabled {
+                if let Some(bus) = self.pipeline.bus() {
+                    // Poll for pending messages
+                    while let Some(message) = bus.pop() {
+                        if let gst::MessageView::Element(element) = message.view() {
+                            if let Some(structure) = element.structure() {
+                                if structure.name() == "spectrum" {
+                                    info!("🎵 Spectrum data received");
+                                    
+                                    // Extract magnitude values - two possible approaches
+                                    let mut magnitude_values = Vec::with_capacity(128);
+                                    
+                                    // APPROACH 1: Parse from structure string
+                                    let struct_str = structure.to_string();
+                                    if struct_str.contains("magnitude=(float){") {
+                                        // Extract magnitude values from string
+                                        if let Some(start_idx) = struct_str.find("magnitude=(float){") {
+                                            if let Some(end_idx) = struct_str[start_idx..].find("}") {
+                                                let magnitude_str = &struct_str[start_idx + "magnitude=(float){".len()..start_idx + end_idx];
+                                                let values: Vec<&str> = magnitude_str.split(',').collect();
+                                                
+                                                for value_str in values {
+                                                    if let Ok(value) = value_str.trim().parse::<f32>() {
+                                                        magnitude_values.push(value);
+                                                    }
+                                                }
+                                                
+                                                info!("Extracted {} magnitude values from string", magnitude_values.len());
+                                            }
+                                        }
+                                    }
+                                    
+                                    // APPROACH 2: Try to access directly by index if approach 1 fails
+                                    if magnitude_values.is_empty() {
+                                        for i in 0..128 {
+                                            let field_name = format!("magnitude[{}]", i);
+                                            if let Ok(value) = structure.get::<f32>(&field_name) {
+                                                magnitude_values.push(value);
+                                            } else {
+                                                break;
+                                            }
+                                        }
+                                        
+                                        if !magnitude_values.is_empty() {
+                                            info!("Extracted {} magnitude values by field access", magnitude_values.len());
+                                        }
+                                    }
+                                    
+                                    // Process spectrum data if we have it
+                                    if !magnitude_values.is_empty() {
+                                        // Calculate audio metrics
+                                        let bands = magnitude_values.len();
+                                        
+                                        // Calculate average and normalize values
+                                        // Values are in dB (typically negative, with higher/less negative being louder)
+                                        let threshold = self.spectrum_threshold as f32;
+                                        
+                                        // Create normalized values from -60dB (silence) to 0dB (loudest)
+                                        let normalized_values: Vec<f32> = magnitude_values.iter()
+                                            .map(|&v| ((v - threshold) / -threshold).max(0.0).min(1.0))
+                                            .collect();
+                                        
+                                        // Calculate frequency band energy averages (useful for visualization)
+                                        let bass_range = (bands as f32 * 0.1) as usize; // First 10% of frequencies
+                                        let mid_range_start = bass_range;
+                                        let mid_range_end = (bands as f32 * 0.5) as usize; // 10-50% of frequencies
+                                        let high_range_start = mid_range_end;
+                                        
+                                        let bass_energy = if bass_range > 0 {
+                                            normalized_values[0..bass_range].iter().sum::<f32>() / bass_range as f32
+                                        } else {
+                                            0.0
+                                        };
+                                        
+                                        let mid_energy = if mid_range_end > mid_range_start {
+                                            normalized_values[mid_range_start..mid_range_end].iter().sum::<f32>() 
+                                            / (mid_range_end - mid_range_start) as f32
+                                        } else {
+                                            0.0
+                                        };
+                                        
+                                        let high_energy = if bands > high_range_start {
+                                            normalized_values[high_range_start..].iter().sum::<f32>() 
+                                            / (bands - high_range_start) as f32
+                                        } else {
+                                            0.0
+                                        };
+                                        
+                                        // Find peak frequency band
+                                        let peak_info = normalized_values.iter()
+                                            .enumerate()
+                                            .max_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+                                        
+                                        if let Some((peak_idx, &peak_val)) = peak_info {
+                                            let peak_freq = (peak_idx as f32 / bands as f32) * 20000.0; // Rough estimate of frequency
+                                            info!("Peak freq: ~{:.0} Hz (band {}, val: {:.2})", peak_freq, peak_idx, peak_val);
+                                        }
+                                        
+                                        // Log energy metrics
+                                        info!("Audio energy - Bass: {:.2}, Mid: {:.2}, High: {:.2}", 
+                                             bass_energy, mid_energy, high_energy);
+                                        
+                                        // Update spectrum data
+                                        if let Ok(mut data) = self.spectrum_data.lock() {
+                                            *data = SpectrumData {
+                                                bands,
+                                                magnitudes: magnitude_values,
+                                                phases: None,
+                                                timestamp: structure.get("timestamp").ok(),
+                                            };
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
             // ALWAYS recreate the texture for the first frame or if dimensions don't match
             let should_recreate = !self.texture_initialized || 
                                  self.dimensions != (width, height) ||
@@ -651,6 +938,73 @@ impl VideoTextureManager {
     
     pub fn path(&self) -> &str {
         &self.video_path
+    }
+    
+    /// Configure spectrum analysis parameters
+    pub fn configure_spectrum(&mut self, bands: usize, threshold: i32) -> Result<()> {
+        if !self.has_audio {
+            debug!("Ignoring spectrum configuration - video has no audio");
+            return Ok(());
+        }
+        
+        self.spectrum_bands = bands;
+        self.spectrum_threshold = threshold;
+        
+        if let Some(spectrum_elem) = self.pipeline.by_name("spectrum") {
+            spectrum_elem.set_property("bands", bands as u32);
+            spectrum_elem.set_property("threshold", threshold);
+            info!("Configured spectrum: {} bands, {}dB threshold", bands, threshold);
+            Ok(())
+        } else {
+            warn!("Spectrum element not found in pipeline");
+            Ok(()) // Don't fail if element not found
+        }
+    }
+    
+    /// Enable or disable spectrum analysis
+    pub fn enable_spectrum(&mut self, enabled: bool) -> Result<()> {
+        if !self.has_audio {
+            debug!("Ignoring spectrum enable request - video has no audio");
+            return Ok(());
+        }
+        
+        self.spectrum_enabled = enabled;
+        
+        if let Some(spectrum_elem) = self.pipeline.by_name("spectrum") {
+            spectrum_elem.set_property("post-messages", enabled);
+            info!("Spectrum analysis {} ", if enabled { "enabled" } else { "disabled" });
+            Ok(())
+        } else {
+            warn!("Spectrum element not found in pipeline");
+            Ok(()) // Don't fail if element not found
+        }
+    }
+    
+    /// Get current spectrum data
+    pub fn spectrum_data(&self) -> SpectrumData {
+        match self.spectrum_data.lock() {
+            Ok(data) => data.clone(),
+            Err(_) => SpectrumData::default(),
+        }
+    }
+    
+    /// Set interval between spectrum updates in milliseconds
+    pub fn set_spectrum_interval(&mut self, interval_ms: u64) -> Result<()> {
+        if !self.has_audio {
+            debug!("Ignoring spectrum interval request - video has no audio");
+            return Ok(());
+        }
+        
+        if let Some(spectrum_elem) = self.pipeline.by_name("spectrum") {
+            // Convert milliseconds to nanoseconds for GStreamer
+            let interval_ns = interval_ms * 1_000_000;
+            spectrum_elem.set_property("interval", interval_ns as u64);
+            info!("Set spectrum interval to {}ms", interval_ms);
+            Ok(())
+        } else {
+            warn!("Spectrum element not found in pipeline");
+            Ok(()) // Don't fail if element not found
+        }
     }
 }
 

--- a/src/uniforms.rs
+++ b/src/uniforms.rs
@@ -7,6 +7,7 @@ pub trait UniformProvider {
 pub struct ResolutionUniform {
     pub dimensions: [f32; 2],
     pub _padding: [f32; 2],
+    pub audio_data: [[f32; 4]; 8],
 }
 
 impl UniformProvider for ResolutionUniform {

--- a/src/uniforms.rs
+++ b/src/uniforms.rs
@@ -7,7 +7,8 @@ pub trait UniformProvider {
 pub struct ResolutionUniform {
     pub dimensions: [f32; 2],
     pub _padding: [f32; 2],
-    pub audio_data: [[f32; 4]; 8],
+    pub audio_data: [[f32; 4]; 32],
+    pub audio_raw: [[f32; 4]; 32],
 }
 
 impl UniformProvider for ResolutionUniform {


### PR DESCRIPTION
added: 128 spectrum bands via gstreamer
added: simple audio visualizer shader using both processed (on Rust side) and raw spectrum bands on 

please see:
https://gstreamer.freedesktop.org/documentation/spectrum/index.html?gi-language=c



https://github.com/user-attachments/assets/ce8988f7-4cb8-468d-9e7f-714f20a5abb7




