### PR TITLE
Modernize winit integration

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,78 +1,133 @@
 use crate::{Core, ShaderManager};
 use winit::{
     event::*,
-    event_loop::EventLoop,
+    event_loop::{EventLoop, ActiveEventLoop},
     window::WindowAttributes,
     dpi::LogicalSize,
+    application::ApplicationHandler,
 };
+
 pub struct ShaderApp {
-    core: Core,
+    window_title: String,
+    window_size: (u32, u32),
+    core: Option<Core>,
 }
+
 impl ShaderApp {
     pub fn new(window_title: &str, width: u32, height: u32) -> (Self, EventLoop<()>) {
         let event_loop = EventLoop::builder()
             .build()
             .expect("Failed to create event loop");
-        let mut window_attributes = WindowAttributes::default();
-        window_attributes.inner_size = Some(LogicalSize::new(width, height).into());
-        window_attributes.title = String::from(window_title);
-        window_attributes.resizable = true;
+
+        //note: No window creation here - will happen in resumed event
+        let app = Self {
+            window_title: String::from(window_title),
+            window_size: (width, height),
+            core: None,
+        };
+        
+        (app, event_loop)
+    }
+
+    pub fn run<S: ShaderManager + 'static>(
+        self,
+        event_loop: EventLoop<()>,
+        shader_creator: impl FnOnce(&Core) -> S + 'static,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let mut handler = ShaderAppHandler {
+            app: self,
+            shader_creator: Some(Box::new(shader_creator)),
+            shader: None,
+            first_render: true,
+        };
+        
+        Ok(event_loop.run_app(&mut handler)?)
+    }
+
+    pub fn core(&self) -> Option<&Core> {
+        self.core.as_ref()
+    }
+}
+
+// This struct implements ApplicationHandler to handle winit events
+struct ShaderAppHandler<S: ShaderManager> {
+    app: ShaderApp,
+    shader_creator: Option<Box<dyn FnOnce(&Core) -> S + 'static>>,
+    shader: Option<S>,
+    first_render: bool,
+}
+
+impl<S: ShaderManager> ApplicationHandler for ShaderAppHandler<S> {
+    fn resumed(&mut self, event_loop: &ActiveEventLoop) {
+        let window_attributes = WindowAttributes::default()
+            .with_inner_size(LogicalSize::new(self.app.window_size.0, self.app.window_size.1))
+            .with_title(&self.app.window_title)
+            .with_resizable(true);
         let window = event_loop
             .create_window(window_attributes)
             .expect("Failed to create window");
         window.set_window_level(winit::window::WindowLevel::AlwaysOnTop);
         let core = pollster::block_on(Core::new(window));
-        (Self { core }, event_loop)
+        // Initialize the shader with the core if it hasn't been initialized yet
+        if let Some(shader_creator) = self.shader_creator.take() {
+            let shader = shader_creator(&core);
+            self.shader = Some(shader);
+        }
+        
+        self.app.core = Some(core);
     }
-    pub fn run<S: ShaderManager + 'static>(
-        mut self,
-        event_loop: EventLoop<()>,
-        mut shader: S,
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        let mut first_render = true;
-        event_loop.run(move |event, window_target| {
-            match event {
-                Event::WindowEvent {
-                    window_id,
-                    ref event,
-                } if window_id == self.core.window().id() => {
-                    if !shader.handle_input(&self.core, event) {
-                        match event {
-                            WindowEvent::CloseRequested => {
-                                window_target.exit();
-                            }
-                            WindowEvent::Resized(size) => {
-                                self.core.resize(*size);
-                                shader.resize(&self.core);
-                            }
-                            WindowEvent::RedrawRequested => {
-                                shader.update(&self.core);
-                                match shader.render(&self.core) {
-                                    Ok(_) => {
-                                        if first_render {
-                                            first_render = false;
-                                        }
-                                    }
-                                    Err(wgpu::SurfaceError::Lost) => self.core.resize(self.core.size),
-                                    Err(wgpu::SurfaceError::OutOfMemory) => window_target.exit(),
-                                    Err(e) => eprintln!("Render error: {:?}", e),
-                                }
-                            }
-                            _ => {}
+
+    fn window_event(
+        &mut self,
+        event_loop: &ActiveEventLoop,
+        window_id: winit::window::WindowId,
+        event: WindowEvent,
+    ) {
+        // Only process events if core and shader are initialized
+        if let (Some(core), Some(shader)) = (&self.app.core, &mut self.shader) {
+            if window_id == core.window().id() {
+                if !shader.handle_input(core, &event) {
+                    match event {
+                        WindowEvent::CloseRequested => {
+                            event_loop.exit();
                         }
+                        WindowEvent::Resized(size) => {
+                            if let Some(core) = &mut self.app.core {
+                                core.resize(size);
+                                shader.resize(core);
+                            }
+                        }
+                        WindowEvent::RedrawRequested => {
+                            shader.update(core);
+                            match shader.render(core) {
+                                Ok(_) => {
+                                    if self.first_render {
+                                        self.first_render = false;
+                                    }
+                                }
+                                Err(wgpu::SurfaceError::Lost) => {
+                                    if let Some(core) = &mut self.app.core {
+                                        core.resize(core.size);
+                                    }
+                                }
+                                Err(wgpu::SurfaceError::OutOfMemory) => event_loop.exit(),
+                                Err(e) => eprintln!("Render error: {:?}", e),
+                            }
+                        }
+                        _ => {}
                     }
                 }
-                Event::AboutToWait => {
-                    self.core.window().request_redraw();
-                }
-                _ => {}
             }
-        })?;
-
-        Ok(())
+        }
     }
 
-    pub fn core(&self) -> &Core {
-        &self.core
+    fn about_to_wait(&mut self, _event_loop: &ActiveEventLoop) {
+        if let Some(core) = &self.app.core {
+            core.window().request_redraw();
+        }
+    }
+    
+    fn new_events(&mut self, _event_loop: &ActiveEventLoop, _cause: StartCause) {
+        // No special handling needed for new events
     }
 }

--- a/src/bin/2dneuron.rs
+++ b/src/bin/2dneuron.rs
@@ -853,6 +853,7 @@ impl ShaderManager for Shader {
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
     let (app, event_loop) = ShaderApp::new("2dneuron", 320, 420);
-    let shader = Shader::init(app.core());
-    app.run(event_loop, shader)
+    app.run(event_loop, |core| {
+        Shader::init(core)
+    })
 }

--- a/src/bin/asahi.rs
+++ b/src/bin/asahi.rs
@@ -40,8 +40,9 @@ struct Shader {
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
     let (app, event_loop) = ShaderApp::new("asahi", 800, 600);
-    let shader = Shader::init(app.core());
-    app.run(event_loop, shader)
+    app.run(event_loop, |core| {
+        Shader::init(core)
+    })
 }
 impl Shader {
     fn capture_frame(&mut self, core: &Core, time: f32) -> Result<Vec<u8>, wgpu::SurfaceError> {

--- a/src/bin/attractor.rs
+++ b/src/bin/attractor.rs
@@ -585,6 +585,7 @@ fn handle_input(&mut self, core: &Core, event: &WindowEvent) -> bool {
 fn main() -> Result<(), Box<dyn std::error::Error>> {
 env_logger::init();
 let (app, event_loop) = ShaderApp::new("Attractor", 800, 600);
-let shader = AttractorShader::init(app.core());
-app.run(event_loop, shader)
+app.run(event_loop, |core| {
+    AttractorShader::init(core)
+})
 }

--- a/src/bin/audiovis.rs
+++ b/src/bin/audiovis.rs
@@ -25,8 +25,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
     //std::env::set_var("GST_DEBUG", "bpmdetect:5,pitch:5,soundtouch:5,bus:4,element:4");
     let (app, event_loop) = ShaderApp::new("audiovis", 800, 600);
-    let shader = AudioVis::init(app.core());
-    app.run(event_loop, shader)
+    app.run(event_loop, |core| {
+        AudioVis::init(core)
+    })
 }
 struct AudioVis {
     base: BaseShader,

--- a/src/bin/clifford.rs
+++ b/src/bin/clifford.rs
@@ -503,6 +503,7 @@ impl ShaderManager for FeedbackShader {
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
     let (app, event_loop) = ShaderApp::new("Clifford", 800, 600);
-    let shader = FeedbackShader::init(app.core());
-    app.run(event_loop, shader)
+    app.run(event_loop, |core| {
+        FeedbackShader::init(core)
+    })
 }

--- a/src/bin/cuneus.rs
+++ b/src/bin/cuneus.rs
@@ -54,8 +54,9 @@ struct Shader {
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
     let (app, event_loop) = ShaderApp::new("cuneus", 800, 600);
-    let shader = Shader::init(app.core());
-    app.run(event_loop, shader)
+    app.run(event_loop, |core| {
+        Shader::init(core)
+    })
 }
 
 impl Shader {

--- a/src/bin/dna.rs
+++ b/src/bin/dna.rs
@@ -50,8 +50,9 @@ struct Shader {
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
     let (app, event_loop) = ShaderApp::new("Vertices", 800, 600);
-    let shader = Shader::init(app.core());
-    app.run(event_loop, shader)
+    app.run(event_loop, |core| {
+        Shader::init(core)
+    })
 }
 impl Shader {
     fn capture_frame(&mut self, core: &Core, time: f32) -> Result<Vec<u8>, wgpu::SurfaceError> {

--- a/src/bin/droste.rs
+++ b/src/bin/droste.rs
@@ -28,8 +28,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     cuneus::gst::init()?;
     env_logger::init();
     let (app, event_loop) = ShaderApp::new("Droste", 800, 600);
-    let shader = SpiralShader::init(app.core());
-    app.run(event_loop, shader)
+    app.run(event_loop, |core| {
+        SpiralShader::init(core)
+    })
 }
 
 struct SpiralShader {

--- a/src/bin/fluid.rs
+++ b/src/bin/fluid.rs
@@ -550,6 +550,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     cuneus::gst::init()?;
     env_logger::init();
     let (app, event_loop) = ShaderApp::new("Fluid", 800, 600);
-    let shader = FluidShader::init(app.core());
-    app.run(event_loop, shader)
+    app.run(event_loop, |core| {
+        FluidShader::init(core)
+    })
 }

--- a/src/bin/gabornoise.rs
+++ b/src/bin/gabornoise.rs
@@ -32,8 +32,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     cuneus::gst::init()?;
     env_logger::init();
     let (app, event_loop) = ShaderApp::new("gabornoise", 800, 600);
-    let shader = SpiralShader::init(app.core());
-    app.run(event_loop, shader)
+    app.run(event_loop, |core| {
+        SpiralShader::init(core)
+    })
 }
 
 struct SpiralShader {

--- a/src/bin/galaxy.rs
+++ b/src/bin/galaxy.rs
@@ -32,8 +32,9 @@ struct Shader {
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
     let (app, event_loop) = ShaderApp::new("galaxy", 800, 600);
-    let shader = Shader::init(app.core());
-    app.run(event_loop, shader)
+    app.run(event_loop, |core| {
+        Shader::init(core)
+    })
 }
 impl Shader {
     fn capture_frame(&mut self, core: &Core, time: f32) -> Result<Vec<u8>, wgpu::SurfaceError> {

--- a/src/bin/genuary2025_18.rs
+++ b/src/bin/genuary2025_18.rs
@@ -654,6 +654,7 @@ fn handle_input(&mut self, core: &Core, event: &WindowEvent) -> bool {
 fn main() -> Result<(), Box<dyn std::error::Error>> {
 env_logger::init();
 let (app, event_loop) = ShaderApp::new("genuary2025_18", 800, 600);
-let shader = Shader::init(app.core());
-app.run(event_loop, shader)
+app.run(event_loop, |core| {
+    Shader::init(core)
+})
 }

--- a/src/bin/genuary2025_6.rs
+++ b/src/bin/genuary2025_6.rs
@@ -33,8 +33,9 @@ struct Shader {
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
     let (app, event_loop) = ShaderApp::new("sinh", 800, 600);
-    let shader = Shader::init(app.core());
-    app.run(event_loop, shader)
+    app.run(event_loop, |core| {
+        Shader::init(core)
+    })
 }
 impl Shader {
     fn capture_frame(&mut self, core: &Core, time: f32) -> Result<Vec<u8>, wgpu::SurfaceError> {

--- a/src/bin/hilbert.rs
+++ b/src/bin/hilbert.rs
@@ -37,8 +37,9 @@ struct Shader {
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
     let (app, event_loop) = ShaderApp::new("hilbert", 800, 600);
-    let shader = Shader::init(app.core());
-    app.run(event_loop, shader)
+    app.run(event_loop, |core| {
+        Shader::init(core)
+    })
 }
 impl Shader {
     fn capture_frame(&mut self, core: &Core, time: f32) -> Result<Vec<u8>, wgpu::SurfaceError> {

--- a/src/bin/lich.rs
+++ b/src/bin/lich.rs
@@ -658,6 +658,7 @@ fn handle_input(&mut self, core: &Core, event: &WindowEvent) -> bool {
 fn main() -> Result<(), Box<dyn std::error::Error>> {
 env_logger::init();
 let (app, event_loop) = ShaderApp::new("Lich", 800, 600);
-let shader = AttractorShader::init(app.core());
-app.run(event_loop, shader)
+app.run(event_loop, |core| {
+    AttractorShader::init(core)
+})
 }

--- a/src/bin/mandelbrot.rs
+++ b/src/bin/mandelbrot.rs
@@ -41,8 +41,9 @@ struct Shader {
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
     let (app, event_loop) = ShaderApp::new("test shader", 800, 600);
-    let shader = Shader::init(app.core());
-    app.run(event_loop, shader)
+    app.run(event_loop, |core| {
+        Shader::init(core)
+    })
 }
 impl Shader {
     fn capture_frame(&mut self, core: &Core, time: f32) -> Result<Vec<u8>, wgpu::SurfaceError> {

--- a/src/bin/mandelbulb.rs
+++ b/src/bin/mandelbulb.rs
@@ -42,8 +42,9 @@ struct Shader {
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
     let (app, event_loop) = ShaderApp::new("mandelbulb", 800, 600);
-    let shader = Shader::init(app.core());
-    app.run(event_loop, shader)
+    app.run(event_loop, |core| {
+        Shader::init(core)
+    })
 }
 impl Shader {
     fn capture_frame(&mut self, core: &Core, time: f32) -> Result<Vec<u8>, wgpu::SurfaceError> {

--- a/src/bin/matrix.rs
+++ b/src/bin/matrix.rs
@@ -25,8 +25,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
     //std::env::set_var("GST_DEBUG", "spectrum:5");
     let (app, event_loop) = ShaderApp::new("matrix", 800, 600);
-    let shader = MatrixShader::init(app.core());
-    app.run(event_loop, shader)
+    app.run(event_loop, |core| {
+        MatrixShader::init(core)
+    })
 }
 struct MatrixShader {
     base: BaseShader,

--- a/src/bin/nebula.rs
+++ b/src/bin/nebula.rs
@@ -38,8 +38,9 @@ struct Shader {
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
     let (app, event_loop) = ShaderApp::new("nebula", 800, 600);
-    let shader = Shader::init(app.core());
-    app.run(event_loop, shader)
+    app.run(event_loop, |core| {
+        Shader::init(core)
+    })
 }
 impl Shader {
     fn capture_frame(&mut self, core: &Core, time: f32) -> Result<Vec<u8>, wgpu::SurfaceError> {

--- a/src/bin/orbits.rs
+++ b/src/bin/orbits.rs
@@ -52,8 +52,9 @@ struct Shader {
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
     let (app, event_loop) = ShaderApp::new("orbits", 800, 600);
-    let shader = Shader::init(app.core());
-    app.run(event_loop, shader)
+    app.run(event_loop, |core| {
+        Shader::init(core)
+    })
 }
 impl Shader {
     fn capture_frame(&mut self, core: &Core, _time: f32) -> Result<Vec<u8>, wgpu::SurfaceError> {

--- a/src/bin/poe2.rs
+++ b/src/bin/poe2.rs
@@ -46,8 +46,9 @@ struct Shader {
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
     let (app, event_loop) = ShaderApp::new("poe", 800, 600);
-    let shader = Shader::init(app.core());
-    app.run(event_loop, shader)
+    app.run(event_loop, |core| {
+        Shader::init(core)
+    })
 }
 impl Shader {
     fn capture_frame(&mut self, core: &Core, time: f32) -> Result<Vec<u8>, wgpu::SurfaceError> {

--- a/src/bin/rorschach.rs
+++ b/src/bin/rorschach.rs
@@ -519,6 +519,7 @@ impl ShaderManager for Shader {
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
     let (app, event_loop) = ShaderApp::new("inkblot", 800, 600);
-    let shader = Shader::init(app.core());
-    app.run(event_loop, shader)
+    app.run(event_loop, |core| {
+        Shader::init(core)
+    })
 }

--- a/src/bin/roto.rs
+++ b/src/bin/roto.rs
@@ -39,8 +39,9 @@ struct Shader {
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
     let (app, event_loop) = ShaderApp::new("rotation_illusion", 800, 600);
-    let shader = Shader::init(app.core());
-    app.run(event_loop, shader)
+    app.run(event_loop, |core| {
+        Shader::init(core)
+    })
 }
 
 impl Shader {

--- a/src/bin/satan.rs
+++ b/src/bin/satan.rs
@@ -593,6 +593,7 @@ fn handle_input(&mut self, core: &Core, event: &WindowEvent) -> bool {
 fn main() -> Result<(), Box<dyn std::error::Error>> {
 env_logger::init();
 let (app, event_loop) = ShaderApp::new("satan", 800, 600);
-let shader = AttractorShader::init(app.core());
-app.run(event_loop, shader)
+app.run(event_loop, |core| {
+    AttractorShader::init(core)
+})
 }

--- a/src/bin/scenecolor.rs
+++ b/src/bin/scenecolor.rs
@@ -28,8 +28,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     cuneus::gst::init()?;
     env_logger::init();
     let (app, event_loop) = ShaderApp::new("scenecolor", 800, 600);
-    let shader = SpiralShader::init(app.core());
-    app.run(event_loop, shader)
+    app.run(event_loop, |core| {
+        SpiralShader::init(core)
+    })
 }
 
 struct SpiralShader {

--- a/src/bin/sdvert.rs
+++ b/src/bin/sdvert.rs
@@ -42,8 +42,9 @@ struct Shader {
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
     let (app, event_loop) = ShaderApp::new("sdvert", 800, 600);
-    let shader = Shader::init(app.core());
-    app.run(event_loop, shader)
+    app.run(event_loop, |core| {
+        Shader::init(core)
+    })
 }
 impl Shader {
     fn capture_frame(&mut self, core: &Core, time: f32) -> Result<Vec<u8>, wgpu::SurfaceError> {

--- a/src/bin/simplefeedback.rs
+++ b/src/bin/simplefeedback.rs
@@ -428,6 +428,7 @@ impl ShaderManager for FeedbackShader {
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
     let (app, event_loop) = ShaderApp::new("Feedback", 800, 600);
-    let shader = FeedbackShader::init(app.core());
-    app.run(event_loop, shader)
+    app.run(event_loop, |core| {
+        FeedbackShader::init(core)
+    })
 }

--- a/src/bin/sinh.rs
+++ b/src/bin/sinh.rs
@@ -33,8 +33,9 @@ struct Shader {
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
     let (app, event_loop) = ShaderApp::new("sinh", 800, 600);
-    let shader = Shader::init(app.core());
-    app.run(event_loop, shader)
+    app.run(event_loop, |core| {
+        Shader::init(core)
+    })
 }
 impl Shader {
     fn capture_frame(&mut self, core: &Core, time: f32) -> Result<Vec<u8>, wgpu::SurfaceError> {

--- a/src/bin/spiral.rs
+++ b/src/bin/spiral.rs
@@ -22,8 +22,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     cuneus::gst::init()?;
     env_logger::init();
     let (app, event_loop) = ShaderApp::new("Spiral", 800, 600);
-    let shader = SpiralShader::init(app.core());
-    app.run(event_loop, shader)
+    app.run(event_loop, |core| {
+        SpiralShader::init(core)
+    })
 }
 struct SpiralShader {
     base: BaseShader,

--- a/src/bin/tree.rs
+++ b/src/bin/tree.rs
@@ -853,6 +853,7 @@ impl ShaderManager for Shader {
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
     let (app, event_loop) = ShaderApp::new("Fractal Tree", 800, 600);
-    let shader = Shader::init(app.core());
-    app.run(event_loop, shader)
+    app.run(event_loop, |core| {
+        Shader::init(core)
+    })
 }

--- a/src/bin/voronoi.rs
+++ b/src/bin/voronoi.rs
@@ -21,8 +21,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     cuneus::gst::init()?;
     env_logger::init();
     let (app, event_loop) = ShaderApp::new("voronoi", 800, 600);
-    let shader = SpiralShader::init(app.core());
-    app.run(event_loop, shader)
+    app.run(event_loop, |core| {
+        SpiralShader::init(core)
+    })
 }
 struct SpiralShader {
     base: BaseShader,

--- a/src/bin/xmas.rs
+++ b/src/bin/xmas.rs
@@ -42,8 +42,9 @@ struct ChristmasShader {
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
     let (app, event_loop) = ShaderApp::new("xmas", 800, 600);
-    let shader = ChristmasShader::init(app.core());
-    app.run(event_loop, shader)
+    app.run(event_loop, |core| {
+        ChristmasShader::init(core)
+    })
 }
 impl ChristmasShader {
     fn capture_frame(&mut self, core: &Core, time: f32) -> Result<Vec<u8>, wgpu::SurfaceError> {


### PR DESCRIPTION
Updates ShaderApp to use modern Winit API with ApplicationHandler trait. Eliminates deprecated method warnings and follows recommended event-driven window creation patterns.

Still need some tests so WIP