### PR TITLE
Feat: mouse uniforms

### DIFF
--- a/shaders/compute_basic.wgsl
+++ b/shaders/compute_basic.wgsl
@@ -6,6 +6,16 @@ struct TimeUniform {
 };
 @group(0) @binding(0) var<uniform> u_time: TimeUniform;
 @group(1) @binding(0) var output: texture_storage_2d<rgba16float, write>;
+ //simple usage: On this example I show how can we use them on debug scree
+ //note that, WebGPU only supports a maximum of 4 bind groups (0-3). 
+//When adding this, you can also pass this to the “parameters” struct in other shaders. 
+struct MouseUniform {           
+    position: vec2<f32>,         // Normalized position (0.0 to 1.0)
+    click_position: vec2<f32>,   // Position of last click
+    wheel: vec2<f32>,            // Accumulated wheel delta
+    buttons: vec2<u32>,          // Button state bitfield
+};
+@group(2) @binding(0) var<uniform> u_mouse: MouseUniform;
 
 @compute @workgroup_size(16, 16, 1)
 fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
@@ -18,10 +28,33 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
         f32(global_id.x) / f32(dimensions.x),
         f32(global_id.y) / f32(dimensions.y)
     );
-    let col = 0.5 + 0.5 * cos(
+    
+    let mouse_dist = distance(uv, u_mouse.position);
+    
+    let base_col = 0.5 + 0.5 * cos(
         u_time.time + 
         uv.xyx * 1.0 + 
         vec3<f32>(0.0, 2.0, 4.0)
     );
-    textureStore(output, global_id.xy, vec4<f32>(col, 1.0));
+    
+    let circle_radius = 0.1 + sin(u_time.time) * 0.05;
+    let circle_effect = smoothstep(circle_radius, circle_radius - 0.02, mouse_dist);
+    
+    let circle_col = vec3<f32>(
+        0.5 + 0.5 * sin(u_time.time * 1.1),
+        0.5 + 0.5 * sin(u_time.time * 0.7),
+        0.5 + 0.5 * sin(u_time.time * 0.5)
+    );
+    
+    let left_button_pressed = (u_mouse.buttons.x & 1u) != 0u;
+    var final_col = mix(base_col, circle_col, circle_effect);
+    if (left_button_pressed && mouse_dist < circle_radius) {
+        final_col = vec3<f32>(1.0) - final_col;
+    }
+    let wheel_effect = abs(u_mouse.wheel.y) * 0.2;
+    let pulse = sin(u_time.time * 5.0 + mouse_dist * 20.0) * wheel_effect;
+    if (wheel_effect > 0.01) {
+        final_col = final_col * (1.0 + pulse);
+    }
+    textureStore(output, global_id.xy, vec4<f32>(final_col, 1.0));
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub use export::{ExportSettings, ExportManager, ExportError, ExportUiState, save
 pub use hot::ShaderHotReload;
 pub use controls::{ControlsRequest, ShaderControls};
 pub use atomic::AtomicBuffer;
+pub use mouse::*;
 pub struct Core {
     pub surface: wgpu::Surface<'static>,
     pub device: Arc<wgpu::Device>,
@@ -114,3 +115,4 @@ pub mod gst;
 pub mod compute;
 mod spectrum;
 mod fps;
+mod mouse;

--- a/src/mouse.rs
+++ b/src/mouse.rs
@@ -1,0 +1,123 @@
+use crate::UniformProvider;
+use winit::event::WindowEvent;
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
+pub struct MouseUniform {
+    pub position: [f32; 2],
+    pub click_position: [f32; 2],
+    pub wheel: [f32; 2],
+    pub buttons: [u32; 2],
+}
+
+impl Default for MouseUniform {
+    fn default() -> Self {
+        Self {
+            position: [0.0, 0.0],
+            click_position: [0.0, 0.0],
+            wheel: [0.0, 0.0],
+            buttons: [0, 0],
+        }
+    }
+}
+
+impl UniformProvider for MouseUniform {
+    fn as_bytes(&self) -> &[u8] {
+        bytemuck::bytes_of(self)
+    }
+}
+
+pub struct MouseTracker {
+    pub uniform: MouseUniform,
+    pub raw_position: [f32; 2],
+    pub is_inside_window: bool,
+}
+
+impl Default for MouseTracker {
+    fn default() -> Self {
+        Self {
+            uniform: MouseUniform::default(),
+            raw_position: [0.0, 0.0],
+            is_inside_window: false,
+        }
+    }
+}
+
+impl MouseTracker {
+    pub fn new() -> Self {
+        Self::default()
+    }
+    
+    pub fn handle_mouse_input(
+        &mut self, 
+        event: &WindowEvent, 
+        window_size: [f32; 2],
+        ui_handled: bool
+    ) -> bool {
+        // If UI already handled the event, don't update mouse for shader
+        if ui_handled {
+            return false;
+        }
+        
+        match event {
+            WindowEvent::CursorMoved { position, .. } => {
+                let x = position.x as f32;
+                let y = position.y as f32;
+                self.raw_position = [x, y];
+                
+                self.uniform.position[0] = x / window_size[0];
+                self.uniform.position[1] = y / window_size[1];
+                true
+            },
+            WindowEvent::MouseInput { state, button, .. } => {
+                use winit::event::{ElementState, MouseButton};
+                
+                let pressed = *state == ElementState::Pressed;
+                let bit_mask = match button {
+                    MouseButton::Left => 1,
+                    MouseButton::Right => 2,
+                    MouseButton::Middle => 4,
+                    MouseButton::Back => 8,
+                    MouseButton::Forward => 16,
+                    MouseButton::Other(b) => if *b < 27 { 1 << (b + 5) } else { 0 },
+                };
+                
+                if pressed {
+                    self.uniform.buttons[0] |= bit_mask;
+                    self.uniform.click_position = self.uniform.position;
+                } else {
+                    self.uniform.buttons[0] &= !bit_mask;
+                }
+                true
+            },
+            WindowEvent::MouseWheel { delta, .. } => {
+                use winit::event::MouseScrollDelta;
+                
+                match delta {
+                    MouseScrollDelta::LineDelta(x, y) => {
+                        self.uniform.wheel[0] += *x;
+                        self.uniform.wheel[1] += *y;
+                    },
+                    MouseScrollDelta::PixelDelta(pos) => {
+                        self.uniform.wheel[0] += pos.x as f32 / 100.0;
+                        self.uniform.wheel[1] += pos.y as f32 / 100.0;
+                    }
+                }
+                true
+            },
+            WindowEvent::CursorLeft { .. } => {
+                self.is_inside_window = false;
+                true
+            },
+            WindowEvent::CursorEntered { .. } => {
+                self.is_inside_window = true;
+                true
+            },
+            _ => false,
+        }
+    }
+    
+    pub fn reset_wheel(&mut self) {
+        self.uniform.wheel = [0.0, 0.0];
+    }
+}


### PR DESCRIPTION
with this pr:
- We track normalized and raw positions, button states, and wheel movements
- Allow the compute pipeline to include the mouse uniform when creating the pipeline layout

I made it optional so existing shaders don't break. I added a simple debug screen for the compute.rs example to show how it works. I also implemented a guard to prevent overlapping the mouse event on the egui window (you can look at the compute.rs example: For example, clicking buttons on egui does not affect the main render screen...)