### PR TITLE
Fix immediate texture refresh for compute shaders

### DIFF
--- a/src/bin/computecolors.rs
+++ b/src/bin/computecolors.rs
@@ -605,6 +605,9 @@ impl ShaderManager for ColorProjection {
         }
         self.base.apply_control_request(controls_request.clone());
         self.base.handle_video_requests(core, &controls_request);
+        if controls_request.load_media_path.is_some() {
+            self.recreate_compute_resources(core);
+        }
         if self.base.handle_hdri_requests(core, &controls_request) {
             self.recreate_compute_resources(core);
         }

--- a/src/bin/fft.rs
+++ b/src/bin/fft.rs
@@ -753,6 +753,13 @@ impl ShaderManager for FFTShader {
         }
         self.base.apply_control_request(controls_request.clone());
         self.base.handle_video_requests(core, &controls_request);
+        if controls_request.load_media_path.is_some() {
+            self.recreate_compute_resources(core);
+            self.should_initialize = true;
+        }
+        if self.base.handle_hdri_requests(core, &controls_request) {
+            self.recreate_compute_resources(core);
+        }
         if self.base.handle_hdri_requests(core, &controls_request) {
             self.recreate_compute_resources(core);
         }
@@ -770,6 +777,9 @@ impl ShaderManager for FFTShader {
         if changed {
             self.params_uniform.data = params;
             self.params_uniform.update(&core.queue);
+            
+            // Add this line - it's the key fix:
+            self.should_initialize = true;
         }
         
         if should_start_export {

--- a/src/bin/pathtracing.rs
+++ b/src/bin/pathtracing.rs
@@ -776,6 +776,7 @@ impl ShaderManager for PathTracingShader {
         
         if controls_request.should_clear_buffers || self.should_reset_accumulation {
             self.clear_atomic_buffer(core);
+            self.recreate_compute_resources(core);
         }
         self.base.apply_control_request(controls_request.clone());
         self.base.handle_video_requests(core, &controls_request);


### PR DESCRIPTION
This fixes the issue where compute shaders weren't immediately showing updated textures after media loading or parameter changes.