### PR TITLE
Feat  make g streamer dependencies optional

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,13 +18,13 @@ jobs:
           - group: "media"
             features: ""
             gstreamer_required: true
-            shaders: "audiovis,computecolors,droste,fft,gabornoise,matrix,pathtracing,scenecolor,spiral,voronoi"
+            shaders: "audiovis,fluid,computecolors,droste,fft,gabornoise,matrix,pathtracing,scenecolor,spiral,voronoi"
           
           # Shaders that DON'T need GStreamer (pure GPU compute)
           - group: "no-media" 
             features: "--no-default-features"
             gstreamer_required: false
-            shaders: "asahi,buddhabrot,cnn,gabor,lorenz,fluid,galaxy,lich,mandelbulb,satan,sdvert,sinh,roto,orbits,dna,genuary2025_6,nebula,rorschach,poe2,tree,2dneuron,spiralchaos,cliffordcompute"
+            shaders: "asahi,buddhabrot,cnn,gabor,lorenz,galaxy,lich,mandelbulb,satan,sdvert,sinh,roto,orbits,dna,genuary2025_6,nebula,rorschach,poe2,tree,2dneuron,spiralchaos,cliffordcompute"
         
         include:
           - os: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,19 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        shader: [asahi, buddhabrot, cnn, pathtracing, fft, gabor, lorenz, droste, fluid, galaxy, lich, mandelbulb, satan, sdvert, sinh, spiral, roto, orbits, dna, genuary2025_6, nebula, rorschach, poe2, voronoi, tree, matrix, gabornoise, scenecolor,audiovis,2dneuron,spiralchaos,cliffordcompute]
+        shader_config:
+          # Shaders that REQUIRE GStreamer (media features)
+          - group: "media"
+            features: ""
+            gstreamer_required: true
+            shaders: "audiovis,computecolors,droste,fft,gabornoise,matrix,pathtracing,scenecolor,spiral,voronoi"
+          
+          # Shaders that DON'T need GStreamer (pure GPU compute)
+          - group: "no-media" 
+            features: "--no-default-features"
+            gstreamer_required: false
+            shaders: "asahi,buddhabrot,cnn,gabor,lorenz,fluid,galaxy,lich,mandelbulb,satan,sdvert,sinh,roto,orbits,dna,genuary2025_6,nebula,rorschach,poe2,tree,2dneuron,spiralchaos,cliffordcompute"
+        
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
@@ -36,9 +48,9 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      # Install GStreamer for macOS
+      # Install GStreamer for macOS (only for media shaders)
       - name: Install macOS dependencies
-        if: runner.os == 'macOS'
+        if: runner.os == 'macOS' && matrix.shader_config.gstreamer_required
         run: |
           # Download and install official GStreamer packages
           GSTREAMER_VERSION="1.26.0"
@@ -53,9 +65,9 @@ jobs:
           echo "GST_PLUGIN_PATH=/Library/Frameworks/GStreamer.framework/Versions/1.0/lib/gstreamer-1.0" >> $GITHUB_ENV
           echo "DYLD_FALLBACK_LIBRARY_PATH=/Library/Frameworks/GStreamer.framework/Versions/1.0/lib" >> $GITHUB_ENV
 
-      # Install GStreamer for Linux
+      # Install GStreamer for Linux (only for media shaders)
       - name: Install Linux dependencies
-        if: runner.os == 'Linux'
+        if: runner.os == 'Linux' && matrix.shader_config.gstreamer_required
         run: |
           sudo apt-get update
           sudo apt-get install -y \
@@ -71,9 +83,9 @@ jobs:
             gstreamer1.0-plugins-bad \
             gstreamer1.0-plugins-ugly
 
-      # Install GStreamer for Windows
+      # Install GStreamer for Windows (only for media shaders)
       - name: Install Windows dependencies
-        if: runner.os == 'Windows'
+        if: runner.os == 'Windows' && matrix.shader_config.gstreamer_required
         shell: pwsh
         run: |
           Write-Host "Starting GStreamer installation process..."
@@ -135,66 +147,94 @@ jobs:
           "PKG_CONFIG_PATH=$expectedPath\lib\pkgconfig" | Out-File -FilePath $env:GITHUB_ENV -Append
           "PATH=$expectedPath\bin;$env:Path" | Out-File -FilePath $env:GITHUB_ENV -Append
 
-      # Build the binary
-      - name: Build binary
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release --bin ${{ matrix.shader }}
-
-      # Create release directory structure and copy files
-      - name: Prepare release package
+      # Build all binaries for this shader group
+      - name: Build binaries
         shell: bash
         run: |
-          # Create directory structure
-          mkdir -p release/${{ matrix.shader }}/shaders
-          
-          # Copy the binary
-          cp "target/release/${{ matrix.shader }}${{ matrix.ext }}" "release/${{ matrix.shader }}/"
-          
-          # Copy shader files
-          cp shaders/${{ matrix.shader }}.wgsl release/${{ matrix.shader }}/shaders/
-          cp shaders/vertex.wgsl release/${{ matrix.shader }}/shaders/
-          
-          # Create a README file
-          echo "${{ matrix.shader }} Shader" > release/${{ matrix.shader }}/README.txt
-          echo "Requirements:" >> release/${{ matrix.shader }}/README.txt
-          echo "1. GStreamer 1.26.0 or later must be installed on your system." >> release/${{ matrix.shader }}/README.txt
-          echo "   Download from: https://gstreamer.freedesktop.org/download/" >> release/${{ matrix.shader }}/README.txt
-          echo "2. The 'shaders' directory must remain in the same folder as the executable." >> release/${{ matrix.shader }}/README.txt
-          
-          # Windows-specific: create .bat launcher
-          if [[ "${{ runner.os }}" == "Windows" ]]; then
-            echo "@echo off" > release/${{ matrix.shader }}/run_${{ matrix.shader }}.bat
-            echo "if not exist shaders mkdir shaders" >> release/${{ matrix.shader }}/run_${{ matrix.shader }}.bat
-            echo "${{ matrix.shader }}.exe" >> release/${{ matrix.shader }}/run_${{ matrix.shader }}.bat
-          fi
+          echo "Building ${{ matrix.shader_config.group }} shaders with features: ${{ matrix.shader_config.features }}"
+          IFS=',' read -ra SHADERS <<< "${{ matrix.shader_config.shaders }}"
+          for shader in "${SHADERS[@]}"; do
+            echo "Building shader: $shader"
+            cargo build --release --bin "$shader" ${{ matrix.shader_config.features }}
+          done
 
-          # Create launcher script for Linux/MacOS
-          if [[ "${{ runner.os }}" != "Windows" ]]; then
-            echo '#!/bin/bash' > release/${{ matrix.shader }}/run_${{ matrix.shader }}.sh
-            echo 'mkdir -p shaders' >> release/${{ matrix.shader }}/run_${{ matrix.shader }}.sh
-            echo './${{ matrix.shader }}' >> release/${{ matrix.shader }}/run_${{ matrix.shader }}.sh
-            chmod +x release/${{ matrix.shader }}/run_${{ matrix.shader }}.sh
-          fi
+      # Create release packages for each shader in the group
+      - name: Prepare release packages
+        shell: bash
+        run: |
+          IFS=',' read -ra SHADERS <<< "${{ matrix.shader_config.shaders }}"
+          for shader in "${SHADERS[@]}"; do
+            echo "Packaging shader: $shader"
+            
+            # Create directory structure
+            mkdir -p "release/$shader/shaders"
+            
+            # Copy the binary
+            cp "target/release/$shader${{ matrix.ext }}" "release/$shader/"
+            
+            # Copy shader files
+            cp "shaders/$shader.wgsl" "release/$shader/shaders/"
+            cp "shaders/vertex.wgsl" "release/$shader/shaders/"
+            
+            # Create appropriate README based on shader group
+            echo "$shader Shader" > "release/$shader/README.txt"
+            echo "Requirements:" >> "release/$shader/README.txt"
+            
+            if [[ "${{ matrix.shader_config.gstreamer_required }}" == "true" ]]; then
+              echo "1. GStreamer 1.26.0 or later must be installed on your system." >> "release/$shader/README.txt"
+              echo "   Download from: https://gstreamer.freedesktop.org/download/" >> "release/$shader/README.txt"
+              echo "2. The 'shaders' directory must remain in the same folder as the executable." >> "release/$shader/README.txt"
+            else
+              echo "1. No additional dependencies required - just run the executable!" >> "release/$shader/README.txt"
+              echo "2. The 'shaders' directory must remain in the same folder as the executable." >> "release/$shader/README.txt"
+              echo "3. This is a lightweight build without media support." >> "release/$shader/README.txt"
+            fi
+            
+            # Windows-specific: create .bat launcher
+            if [[ "${{ runner.os }}" == "Windows" ]]; then
+              echo "@echo off" > "release/$shader/run_$shader.bat"
+              echo "if not exist shaders mkdir shaders" >> "release/$shader/run_$shader.bat"
+              echo "$shader.exe" >> "release/$shader/run_$shader.bat"
+            fi
 
-      # Create archive
-      - name: Create archive
+            # Create launcher script for Linux/MacOS
+            if [[ "${{ runner.os }}" != "Windows" ]]; then
+              echo '#!/bin/bash' > "release/$shader/run_$shader.sh"
+              echo 'mkdir -p shaders' >> "release/$shader/run_$shader.sh"
+              echo "./$shader" >> "release/$shader/run_$shader.sh"
+              chmod +x "release/$shader/run_$shader.sh"
+            fi
+          done
+
+      # Create archives for each shader
+      - name: Create archives
         shell: bash
         run: |
           cd release
-          if [[ "${{ runner.os }}" == "Windows" ]]; then
-            7z a "../${{ matrix.shader }}-${{ matrix.target }}${{ matrix.archive_ext }}" ${{ matrix.shader }}
-          else
-            tar -czf "../${{ matrix.shader }}-${{ matrix.target }}${{ matrix.archive_ext }}" ${{ matrix.shader }}
-          fi
+          IFS=',' read -ra SHADERS <<< "${{ matrix.shader_config.shaders }}"
+          for shader in "${SHADERS[@]}"; do
+            echo "Creating archive for: $shader"
+            if [[ "${{ runner.os }}" == "Windows" ]]; then
+              7z a "../$shader-${{ matrix.target }}${{ matrix.archive_ext }}" "$shader"
+            else
+              tar -czf "../$shader-${{ matrix.target }}${{ matrix.archive_ext }}" "$shader"
+            fi
+          done
 
-      # Upload artifact
-      - name: Upload artifact
+      # Upload artifacts for each shader
+      - name: Upload artifacts
+        shell: bash
+        run: |
+          IFS=',' read -ra SHADERS <<< "${{ matrix.shader_config.shaders }}"
+          for shader in "${SHADERS[@]}"; do
+            echo "Uploading artifact for: $shader"
+          done
+          
+      - name: Upload artifacts to GitHub
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.shader }}-${{ matrix.target }}
-          path: ${{ matrix.shader }}-${{ matrix.target }}${{ matrix.archive_ext }}
+          name: ${{ matrix.shader_config.group }}-${{ matrix.target }}
+          path: "*-${{ matrix.target }}${{ matrix.archive_ext }}"
 
   release:
     needs: [build]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -819,7 +819,7 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "cuneus"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,13 +22,17 @@ env_logger = "0.11.6"
 pollster = "0.4.0"
 rfd = "0.15.1"
 notify = "7.0.0"
-gstreamer = "0.23.4"
-gstreamer-video = "0.23.4"
-gstreamer-app = "0.23.4"
-gstreamer-pbutils = "0.23.4"
+gstreamer = { version = "0.23.4", optional = true }
+gstreamer-video = { version = "0.23.4", optional = true }
+gstreamer-app = { version = "0.23.4", optional = true }
+gstreamer-pbutils = { version = "0.23.4", optional = true }
 anyhow = "1.0.96"
 log = "0.4.25"
 fontdue = "0.9.0"
+
+[features]
+default = ["media"]
+media = ["gstreamer", "gstreamer-video", "gstreamer-app", "gstreamer-pbutils"]
 
 [dev-dependencies]
 crossterm = "0.28.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cuneus"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["altunenes"]
 description = "A WGPU-based shader development tool"

--- a/src/controls.rs
+++ b/src/controls.rs
@@ -1,4 +1,5 @@
 use std::path::PathBuf;
+#[cfg(feature = "media")]
 use crate::gst::video::VideoTextureManager;
 use crate::hdri::HdriMetadata;
 #[derive(Clone)]
@@ -178,6 +179,7 @@ impl ShaderControls {
     }
 
     /// Extract video info from a video texture manager
+    #[cfg(feature = "media")]
     pub fn get_video_info(
         using_video_texture: bool,
         video_manager: Option<&VideoTextureManager>,

--- a/src/gst/mod.rs
+++ b/src/gst/mod.rs
@@ -1,12 +1,20 @@
+#[cfg(feature = "media")]
 pub mod video;
 
 use log::info;
 
+#[cfg(feature = "media")]
 pub fn init() -> anyhow::Result<()> {
     // These are active untill I merge the PR
     //std::env::set_var("GST_DEBUG", "bpmdetect:5,pitch:5,soundtouch:5,bus:4,element:4");
     info!("Setting up GStreamer with enhanced logging");
     gstreamer::init()?;
     info!("GStreamer initialized successfully");
+    Ok(())
+}
+
+#[cfg(not(feature = "media"))]
+pub fn init() -> anyhow::Result<()> {
+    info!("Media support disabled - skipping GStreamer initialization");
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ mod export;
 mod hot;
 mod controls;
 mod atomic;
+#[cfg(feature = "media")]
 pub mod gst;
 pub mod compute;
 mod spectrum;
@@ -55,7 +56,12 @@ pub mod prelude {
         RenderKit, ShaderControls, ExportManager, ShaderHotReload,
         TextureManager, Renderer, AtomicBuffer,
         KeyInputHandler, ControlsRequest, FontSystem, FontUniforms,
-        gst, save_frame, compute::create_bind_group_layout,compute::BindGroupLayoutType
+        save_frame, compute::create_bind_group_layout,compute::BindGroupLayoutType
+    };
+    
+    #[cfg(feature = "media")]
+    pub use crate::{
+        gst
     };
     
     pub use crate::wgpu;

--- a/src/spectrum.rs
+++ b/src/spectrum.rs
@@ -1,16 +1,23 @@
 // This file is part of the gstreamer, and its inits the spectrum analyzer and bpm.
 // I also did some smoothing related to audio data for the spectrum analyzer.
+#[cfg(feature = "media")]
 use log::info;
+#[cfg(feature = "media")]
 use wgpu;
 
+#[cfg(feature = "media")]
 use crate::gst::video::VideoTextureManager;
+#[cfg(feature = "media")]
 use crate::UniformBinding;
+#[cfg(feature = "media")]
 use crate::ResolutionUniform;
 
 pub struct SpectrumAnalyzer {
+    #[cfg(feature = "media")]
     prev_audio_data: [[f32; 4]; 32],
 }
 
+#[cfg(feature = "media")]
 impl SpectrumAnalyzer {
     pub fn new() -> Self {
         Self {
@@ -163,5 +170,12 @@ impl SpectrumAnalyzer {
             
             resolution_uniform.update(queue);
         }
+    }
+}
+
+#[cfg(not(feature = "media"))]
+impl SpectrumAnalyzer {
+    pub fn new() -> Self {
+        Self {}
     }
 }


### PR DESCRIPTION
 I'm still not sure. can be hard to maintain in future versions...  
 
  - Add media feature flag with GStreamer dependencies
  - Enable building without media support using --no-default-features
  - Maintain full backward compatibility with default media feature
  - Allow lightweight builds for pure GPU compute shaders