### PR TITLE
feat(media): support downloading and trimming YouTube videos

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,7 +294,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix",
+ "rustix 0.38.42",
  "slab",
  "tracing",
  "windows-sys 0.59.0",
@@ -337,7 +337,7 @@ dependencies = [
  "cfg-if",
  "event-listener",
  "futures-lite",
- "rustix",
+ "rustix 0.38.42",
  "tracing",
 ]
 
@@ -364,7 +364,7 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix",
+ "rustix 0.38.42",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.59.0",
@@ -557,7 +557,7 @@ dependencies = [
  "bitflags 2.8.0",
  "log",
  "polling",
- "rustix",
+ "rustix 0.38.42",
  "slab",
  "thiserror 1.0.69",
 ]
@@ -569,7 +569,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95a66a987056935f7efce4ab5668920b5d0dac4a7c99991a67395f13702ddd20"
 dependencies = [
  "calloop",
- "rustix",
+ "rustix 0.38.42",
  "wayland-backend",
  "wayland-client",
 ]
@@ -796,7 +796,7 @@ dependencies = [
  "crossterm_winapi",
  "mio",
  "parking_lot",
- "rustix",
+ "rustix 0.38.42",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -838,8 +838,10 @@ dependencies = [
  "notify",
  "pollster 0.4.0",
  "ratatui",
+ "regex",
  "rfd",
  "wgpu",
+ "which",
  "winit",
 ]
 
@@ -1045,6 +1047,12 @@ dependencies = [
  "log",
  "regex",
 ]
+
+[[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
 
 [[package]]
 name = "env_logger"
@@ -2171,6 +2179,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+
+[[package]]
 name = "litemap"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2886,7 +2900,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix",
+ "rustix 0.38.42",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -3217,7 +3231,20 @@ dependencies = [
  "bitflags 2.8.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.14",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+dependencies = [
+ "bitflags 2.8.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.4",
  "windows-sys 0.59.0",
 ]
 
@@ -3395,7 +3422,7 @@ dependencies = [
  "libc",
  "log",
  "memmap2",
- "rustix",
+ "rustix 0.38.42",
  "thiserror 1.0.69",
  "wayland-backend",
  "wayland-client",
@@ -3545,7 +3572,7 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "once_cell",
- "rustix",
+ "rustix 0.38.42",
  "windows-sys 0.59.0",
 ]
 
@@ -3932,7 +3959,7 @@ checksum = "fe770181423e5fc79d3e2a7f4410b7799d5aab1de4372853de3c6aa13ca24121"
 dependencies = [
  "cc",
  "downcast-rs",
- "rustix",
+ "rustix 0.38.42",
  "scoped-tls",
  "smallvec",
  "wayland-sys",
@@ -3945,7 +3972,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978fa7c67b0847dbd6a9f350ca2569174974cd4082737054dbb7fbb79d7d9a61"
 dependencies = [
  "bitflags 2.8.0",
- "rustix",
+ "rustix 0.38.42",
  "wayland-backend",
  "wayland-scanner",
 ]
@@ -3967,7 +3994,7 @@ version = "0.31.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32b08bc3aafdb0035e7fe0fdf17ba0c09c268732707dca4ae098f60cb28c9e4c"
 dependencies = [
- "rustix",
+ "rustix 0.38.42",
  "wayland-client",
  "xcursor",
 ]
@@ -4184,6 +4211,17 @@ dependencies = [
  "js-sys",
  "log",
  "web-sys",
+]
+
+[[package]]
+name = "which"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fabb953106c3c8eea8306e4393700d7657561cb43122571b172bbfb7c7ba1d"
+dependencies = [
+ "env_home",
+ "rustix 1.0.7",
+ "winsafe",
 ]
 
 [[package]]
@@ -4527,7 +4565,7 @@ dependencies = [
  "pin-project",
  "raw-window-handle",
  "redox_syscall 0.4.1",
- "rustix",
+ "rustix 0.38.42",
  "sctk-adwaita",
  "smithay-client-toolkit",
  "smol_str",
@@ -4555,6 +4593,12 @@ checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "write16"
@@ -4590,7 +4634,7 @@ dependencies = [
  "libc",
  "libloading",
  "once_cell",
- "rustix",
+ "rustix 0.38.42",
  "x11rb-protocol",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,8 @@ gstreamer-pbutils = { version = "0.23.4", optional = true }
 anyhow = "1.0.96"
 log = "0.4.25"
 fontdue = "0.9.0"
+regex = "1.11.1"
+which = "8.0.0"
 
 [features]
 default = ["media"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@ mod fps;
 mod mouse;
 pub mod hdri;
 mod font;
+pub mod media;
 
 pub use renderer::*;
 pub use shader::*;

--- a/src/media.rs
+++ b/src/media.rs
@@ -1,0 +1,268 @@
+// media.rs: YouTube video download and trimming utilities for CUNEUS_MEDIA
+//
+// This module provides functions to download and trim YouTube videos for use in the CUNEUS media pipeline.
+//
+// Main function:
+//   download_youtube_video(video_id, relative_path, start_time, end_time, duration)
+//
+// Parameters:
+//   - video_id: The YouTube video ID (string, e.g. "sKHswNFsRww").
+//   - relative_path: Path to save the output file or directory for output files.
+//   - start_time: Optional start time in seconds for trimming (u64).
+//   - end_time: Optional end time in seconds for trimming (u64).
+//   - duration: Optional duration in seconds for trimming (u64). If set and end_time is not, end_time = start_time + duration.
+//
+// Behavior:
+//   - Downloads the full video if not already present, saving as media/<video_id>.full.mp4.
+//   - If trimming is requested (start_time/end_time/duration), uses ffmpeg to extract the segment and saves as media/<video_id>_start<start>_end<end>.mp4.
+//   - If the trimmed file already exists and matches the requested segment, it is reused.
+//   - All files are retained in the media/ directory for future reuse.
+//   - Returns the path to the ready-to-use video file (full or trimmed).
+//
+// Errors:
+//   - Returns an error if yt-dlp or ffmpeg are not found, or if download/trim fails.
+//   - Returns an error if the requested segment is invalid (e.g., end_time <= start_time).
+
+use std::io;
+use std::io::ErrorKind;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::fs;
+use regex::Regex;
+
+/// Downloads a YouTube video, optionally trimming it to the specified start and end times.
+///
+/// # Parameters
+///
+/// - `video_id`: The YouTube video ID (string, e.g. "sKHswNFsRww").
+/// - `relative_path`: Path to save the output file or directory for output files.
+/// - `start_time`: Optional start time in seconds for trimming (u64).
+/// - `end_time`: Optional end time in seconds for trimming (u64).
+/// - `duration`: Optional duration in seconds for trimming (u64). If set and `end_time` is not, `end_time` = `start_time` + `duration`.
+///
+/// # Behavior
+///
+/// - Downloads the full video if not already present, saving as `media/<video_id>.full.mp4`.
+/// - If trimming is requested (`start_time`/`end_time`/`duration`), uses ffmpeg to extract the segment and saves as `media/<video_id>_start<start>_end<end>.mp4`.
+/// - If the trimmed file already exists and matches the requested segment, it is reused.
+/// - All files are retained in the `media/` directory for future reuse.
+/// - Returns the path to the ready-to-use video file (full or trimmed).
+///
+/// # Errors
+///
+/// - Returns an error if `yt-dlp` or `ffmpeg` are not found, or if download/trim fails.
+/// - Returns an error if the requested segment is invalid (e.g., `end_time` <= `start_time`).
+pub fn download_youtube_video(video_id: &str, relative_path: &Path, start_time: Option<u64>, end_time: Option<u64>, duration: Option<u64>) -> io::Result<PathBuf> {
+    // Use the 'which' crate to resolve yt-dlp and ffmpeg
+    let _ = which::which("yt-dlp").map_err(|_| {
+        io::Error::new(ErrorKind::NotFound, "yt-dlp not found in PATH")
+    })?;
+    let _ = which::which("ffmpeg").map_err(|_| {
+        io::Error::new(ErrorKind::NotFound, "ffmpeg not found in PATH")
+    })?;
+    
+    // Remove any extension from the relative_path before passing to yt-dlp
+    let mut output_path_str = relative_path.to_string_lossy().to_string();
+    if let Some(dotidx) = output_path_str.rfind('.') {
+        output_path_str.truncate(dotidx);
+    }
+    // Use yt-dlp's template to add the correct extension
+    let output_template = format!("{}.%(ext)s", output_path_str);
+    let output_path = Path::new(&output_template);
+    let media_path = output_path.parent().unwrap_or_else(|| Path::new("media"));
+
+    // Check if the media directory exists, if not, create it
+    if !media_path.exists() {
+        fs::create_dir_all(media_path)?;
+    }
+    // Compute the expected full output path
+    let expected_full_output = media_path.join(format!("{}.full.mp4", video_id));
+    // Construct the YouTube URL from the video_id
+    let youtube_url = format!("https://www.youtube.com/watch?v={}", video_id);
+    let resolved_full_output = if expected_full_output.exists() {
+        expected_full_output
+    } else {
+        // Use yt-dlp to resolve the output filename for the full video (dry run)
+        let output_template = format!("{}{}.full.%(ext)s", media_path.display(), video_id);
+        let print_path = Command::new("yt-dlp")
+            .arg("-o").arg(&output_template)
+            .arg("--print").arg("after_move:filepath")
+            .arg(&youtube_url)
+            .output();
+        match print_path {
+            Ok(out) if out.status.success() => {
+                let s = String::from_utf8_lossy(&out.stdout).trim().to_string();
+                if !s.is_empty() { PathBuf::from(s) } else { media_path.join(format!("{}.full.mp4", video_id)) }
+            },
+            _ => media_path.join(format!("{}.full.mp4", video_id)),
+        }
+    };
+    let full_output = &resolved_full_output;
+    // Determine the correct trimmed output file path
+    let trimmed_output = if relative_path.is_dir() {
+        // If only a directory is given, construct a filename
+        let mut fname = format!("{}", video_id);
+        if let Some(start) = start_time {
+            fname.push_str(&format!("_start{}", start));
+        }
+        if let Some(end) = end_time {
+            fname.push_str(&format!("_end{}", end));
+        }
+        fname.push_str(".mp4");
+        relative_path.join(fname)
+    } else {
+        relative_path.to_path_buf()
+    };
+    // Only reuse a trimmed file if its _start and _end match the request exactly (and no extra params)
+    let trimmed_file_stem = trimmed_output.file_stem().and_then(|s| s.to_str()).unwrap_or("");
+    let re_start = Regex::new(r"_start(\d+)").unwrap();
+    let re_end = Regex::new(r"_end(\d+)").unwrap();
+    let file_start = re_start.captures(trimmed_file_stem).and_then(|cap| cap.get(1)).and_then(|m| m.as_str().parse::<u64>().ok());
+    let file_end = re_end.captures(trimmed_file_stem).and_then(|cap| cap.get(1)).and_then(|m| m.as_str().parse::<u64>().ok());
+    // Extra strict: if end_time is None, filename must not contain _end; if start_time is None, must not contain _start
+    let has_start = re_start.is_match(trimmed_file_stem);
+    let has_end = re_end.is_match(trimmed_file_stem);
+    let start_match = start_time == file_start && (start_time.is_some() == has_start);
+    let end_match = end_time == file_end && (end_time.is_some() == has_end);
+    let should_reuse = match (start_time, end_time) {
+        (Some(_), Some(_)) => start_match && end_match,
+        (Some(_), None) => start_match && !has_end,
+        (None, Some(_)) => end_match && !has_start,
+        (None, None) => !has_start && !has_end,
+    };
+    // Download full video if not already present
+    if !full_output.exists() {
+        let mut cmd = Command::new("yt-dlp");
+        cmd.arg("-f").arg("bestvideo[ext=mp4]+bestaudio[ext=m4a]/mp4");
+        cmd.arg("--remux-video").arg("mp4");
+        cmd.arg("-o").arg(full_output.to_str().unwrap());
+        cmd.arg(&youtube_url);
+        let status = dbg!(cmd.status());
+        if !status.as_ref().map(|s| s.success()).unwrap_or(false) {
+            return match status {
+                Ok(status) => Err(io::Error::new(
+                    ErrorKind::Other,
+                    format!("yt-dlp failed with exit code: {}", status.code().unwrap_or(-1)),
+                )),
+                Err(e) => Err(e),
+            };
+        }
+    } else {
+        println!("Full video already exists: {}", full_output.display());
+    }
+    // Check for incomplete download files (.part, .ytdl)
+    let part_file = full_output.with_extension(format!("{}part", full_output.extension().and_then(|e| e.to_str()).unwrap_or("")));
+    let ytdl_file = full_output.with_extension(format!("{}ytdl", full_output.extension().and_then(|e| e.to_str()).unwrap_or("")));
+    if part_file.exists() || ytdl_file.exists() {
+        return Err(io::Error::new(
+            ErrorKind::Other,
+            format!("Full video is still downloading or incomplete: {}", full_output.display()),
+        ));
+    }
+    // Parse start and end time from the filename if present (e.g. ..._start123_end456.mp4)
+    let mut start_time = start_time;
+    let mut end_time = end_time;
+    let file_stem = trimmed_output.file_stem().and_then(|s| s.to_str()).unwrap_or("");
+    let re = Regex::new(r"_start(\d+)").ok();
+    if let Some(re) = &re {
+        if let Some(cap) = re.captures(file_stem) {
+            if let Some(m) = cap.get(1) {
+                if let Ok(val) = m.as_str().parse::<u64>() {
+                    start_time = Some(val);
+                }
+            }
+        }
+    }
+    let re = Regex::new(r"_end(\d+)").ok();
+    if let Some(re) = &re {
+        if let Some(cap) = re.captures(file_stem) {
+            if let Some(m) = cap.get(1) {
+                if let Ok(val) = m.as_str().parse::<u64>() {
+                    end_time = Some(val);
+                }
+            }
+        }
+    }
+    // If duration is set and end_time is not, compute end_time = start_time + duration
+    if duration.is_some() && end_time.is_none() {
+        let s = start_time.unwrap_or(0);
+        end_time = Some(s + duration.unwrap());
+    }
+    // If a section is requested, trim with ffmpeg (support start and end)
+    if start_time.is_some() || end_time.is_some() {
+        // Only trim if the trimmed file does not already exist with exact match
+        if !trimmed_output.exists() || !should_reuse {
+            let mut ffmpeg_cmd = Command::new("ffmpeg");
+            ffmpeg_cmd.arg("-y");
+            let (start, end) = (start_time, end_time);
+            if let Some(start) = start {
+                let hours = start / 3600;
+                let minutes = (start % 3600) / 60;
+                let seconds = start % 60;
+                let start_str = format!("{:02}:{:02}:{:02}", hours, minutes, seconds);
+                ffmpeg_cmd.arg("-ss").arg(&start_str);
+            }
+            ffmpeg_cmd.arg("-i").arg(full_output.to_str().unwrap());
+            // Use -t (duration) if both start and end are set
+            if let (Some(start), Some(end)) = (start, end) {
+                if end > start {
+                    let duration = end - start;
+                    let hours = duration / 3600;
+                    let minutes = (duration % 3600) / 60;
+                    let seconds = duration % 60;
+                    let duration_str = format!("{:02}:{:02}:{:02}", hours, minutes, seconds);
+                    ffmpeg_cmd.arg("-t").arg(&duration_str);
+                } else {
+                    return Err(io::Error::new(
+                        ErrorKind::InvalidInput,
+                        format!("end_time ({}) must be greater than start_time ({})", end, start),
+                    ));
+                }
+            } else if let (None, Some(end)) = (start, end) {
+                let hours = end / 3600;
+                let minutes = (end % 3600) / 60;
+                let seconds = end % 60;
+                let end_str = format!("{:02}:{:02}:{:02}", hours, minutes, seconds);
+                ffmpeg_cmd.arg("-to").arg(&end_str);
+            }
+            // Use re-encode for MP4 output to ensure compatibility
+            ffmpeg_cmd.arg("-c:v").arg("libx264").arg("-c:a").arg("aac");
+            ffmpeg_cmd.arg(&trimmed_output);
+            // Print the full ffmpeg command for debugging
+            let cmdline = format!(
+                "ffmpeg {}",
+                ffmpeg_cmd
+                    .get_args()
+                    .map(|a| a.to_string_lossy())
+                    .collect::<Vec<_>>()
+                    .join(" ")
+            );
+            println!("[DEBUG] Running: {}", cmdline);
+            let ffmpeg_status = ffmpeg_cmd.status();
+            if let Ok(status) = ffmpeg_status {
+                if !status.success() {
+                    return Err(io::Error::new(
+                        ErrorKind::Other,
+                        format!("ffmpeg failed with exit code: {}", status.code().unwrap_or(-1)),
+                    ));
+                }
+            } else if let Err(e) = ffmpeg_status {
+                return Err(io::Error::new(ErrorKind::Other, format!("ffmpeg error: {}", e)));
+            }
+            println!("Trimmed video to {}", trimmed_output.display());
+        } else {
+            println!("Trimmed video already exists: {}", trimmed_output.display());
+        }
+        let trimmed_output_path = trimmed_output.to_path_buf();
+        println!("Video ready at {:?}", trimmed_output_path);
+        Ok(trimmed_output_path)
+    } else {
+        // If no section, just copy the full output to the final output if needed
+        if !trimmed_output.exists() {
+            fs::copy(&full_output, &trimmed_output)?;
+        }
+        let trimmed_output_path = trimmed_output.to_path_buf();
+        println!("Video ready at {:?}", trimmed_output_path);
+        Ok(trimmed_output_path)
+    }
+}


### PR DESCRIPTION
- Added `media.rs` with `download_youtube_video` using `yt-dlp` and `ffmpeg`
- Enabled `regex` and `which` crates for media parsing and tool detection
- Integrated support for YouTube URLs via `CUNEUS_MEDIA` in `ShaderControls`
- Updated `Cargo.lock` to reflect new dependencies