### PR TITLE
Feat: add polyphonic audio synthesis using gstreamer's `audiotestsrc`

### DIFF
--- a/shaders/synth.wgsl
+++ b/shaders/synth.wgsl
@@ -1,0 +1,138 @@
+// An example of a simple audio creation using Cuneus
+@group(0) @binding(0) var<uniform> u_time: ComputeTimeUniform;
+@group(1) @binding(0) var output_texture: texture_storage_2d<rgba16float, write>;
+@group(2) @binding(0) var<uniform> u_audio_synth: AudioSynthUniform;
+
+struct ComputeTimeUniform {
+    time: f32,
+    delta: f32,
+    frame: u32,
+    _padding: u32,
+}
+
+struct AudioSynthUniform {
+    note_frequencies: array<vec4<f32>, 4>,
+    note_amplitudes: array<vec4<f32>, 4>,
+    master_volume: f32,
+    waveform_type: u32,
+    active_note_count: u32,
+    _padding: u32,
+}
+
+// Generate waveform value at screen position based on active notes
+fn get_synth_waveform_value(x: f32, y: f32) -> f32 {
+    if (u_audio_synth.active_note_count == 0u) {
+        return 0.0;
+    }
+    
+    var total_amplitude = 0.0;
+    
+    // Combine all active notes into a waveform
+    for (var i = 0u; i < u_audio_synth.active_note_count && i < 16u; i++) {
+        let vec4_index = i / 4u;
+        let component_index = i % 4u;
+        
+        var frequency = 0.0;
+        var amplitude = 0.0;
+        
+        if (component_index == 0u) {
+            frequency = u_audio_synth.note_frequencies[vec4_index].x;
+            amplitude = u_audio_synth.note_amplitudes[vec4_index].x;
+        } else if (component_index == 1u) {
+            frequency = u_audio_synth.note_frequencies[vec4_index].y;
+            amplitude = u_audio_synth.note_amplitudes[vec4_index].y;
+        } else if (component_index == 2u) {
+            frequency = u_audio_synth.note_frequencies[vec4_index].z;
+            amplitude = u_audio_synth.note_amplitudes[vec4_index].z;
+        } else {
+            frequency = u_audio_synth.note_frequencies[vec4_index].w;
+            amplitude = u_audio_synth.note_amplitudes[vec4_index].w;
+        }
+        
+        if (frequency > 0.0 && amplitude > 0.0) {
+            // Create waveform based on frequency and time
+            let wave_phase = x * frequency * 0.01 + u_time.time * frequency * 0.1;
+            
+            var wave_value = 0.0;
+            if (u_audio_synth.waveform_type == 0u) {
+                // Sine wave
+                wave_value = sin(wave_phase);
+            } else if (u_audio_synth.waveform_type == 1u) {
+                // Square wave
+                wave_value = select(-1.0, 1.0, sin(wave_phase) > 0.0);
+            } else if (u_audio_synth.waveform_type == 2u) {
+                // Saw wave
+                wave_value = (wave_phase % 6.28318) / 3.14159 - 1.0;
+            } else {
+                // Triangle wave
+                let normalized = (wave_phase % 6.28318) / 6.28318;
+                wave_value = select(4.0 * normalized - 1.0, 3.0 - 4.0 * normalized, normalized > 0.5);
+            }
+            
+            total_amplitude += wave_value * amplitude;
+        }
+    }
+    
+    return total_amplitude * u_audio_synth.master_volume;
+}
+
+@compute @workgroup_size(16, 16, 1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let dims = textureDimensions(output_texture);
+    let coord = vec2<i32>(global_id.xy);
+    
+    if coord.x >= i32(dims.x) || coord.y >= i32(dims.y) {
+        return;
+    }
+    
+    let uv = vec2<f32>(coord) / vec2<f32>(dims);
+    
+    var color = vec3<f32>(0.0, 0.0, 0.0);
+    
+    let wave_center_y = 0.5;
+    let wave_height = 0.2;
+    
+    //synthesized waveform value at this position
+    let synth_value = get_synth_waveform_value(uv.x, uv.y);
+    
+    // Create waveform visualization
+    let wave_y = wave_center_y + synth_value * wave_height;
+    
+    let distance_to_wave = abs(uv.y - wave_y);
+    
+    if distance_to_wave < 0.002 {
+        let intensity = abs(synth_value) * u_audio_synth.master_volume;
+        color = vec3<f32>(intensity, intensity * 0.8, intensity * 0.3);
+    } else if distance_to_wave < 0.006 && u_audio_synth.active_note_count > 0u {
+        let glow = (1.0 - distance_to_wave / 0.006) * u_audio_synth.master_volume * 0.3;
+        color = vec3<f32>(glow * 0.7, glow * 0.9, glow * 0.4);
+    }
+    
+    if u_audio_synth.active_note_count > 0u {
+        for (var i = 0u; i < u_audio_synth.active_note_count && i < 16u; i++) {
+            let note_x = f32(i) / 16.0;
+            let note_distance = abs(uv.x - note_x);
+            
+            let vec4_index = i / 4u;
+            let component_index = i % 4u;
+            
+            var note_amplitude = 0.0;
+            if (component_index == 0u) {
+                note_amplitude = u_audio_synth.note_amplitudes[vec4_index].x;
+            } else if (component_index == 1u) {
+                note_amplitude = u_audio_synth.note_amplitudes[vec4_index].y;
+            } else if (component_index == 2u) {
+                note_amplitude = u_audio_synth.note_amplitudes[vec4_index].z;
+            } else {
+                note_amplitude = u_audio_synth.note_amplitudes[vec4_index].w;
+            }
+            
+            if note_distance < 0.02 && note_amplitude > 0.0 {
+                let indicator_strength = (1.0 - note_distance / 0.02) * note_amplitude;
+                color += vec3<f32>(0.2 * indicator_strength, 0.1 * indicator_strength, 0.4 * indicator_strength);
+            }
+        }
+    }
+    
+    textureStore(output_texture, coord, vec4<f32>(color, 1.0));
+}

--- a/src/bin/synth.rs
+++ b/src/bin/synth.rs
@@ -1,0 +1,431 @@
+// An example of a simple audio creation using Cuneus
+use cuneus::{Core, ShaderApp, ShaderManager, RenderKit, ShaderControls, UniformBinding};
+use cuneus::compute::{ComputeShaderConfig, COMPUTE_TEXTURE_FORMAT_RGBA16};
+use cuneus::gst::audio::{AudioSynthManager, MusicalNote, AudioSynthUniform};
+use winit::event::*;
+use winit::keyboard::{KeyCode, PhysicalKey};
+use log::info;
+use std::collections::HashSet;
+use std::path::PathBuf;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    cuneus::gst::init()?;
+    env_logger::init();
+    
+    let (app, event_loop) = ShaderApp::new("Audio Synthesizer", 1200, 800);
+    app.run(event_loop, |core| {
+        SynthManager::init(core)
+    })
+}
+
+struct SynthManager {
+    base: RenderKit,
+    audio_synth: AudioSynthManager,
+    audio_synth_uniform: UniformBinding<AudioSynthUniform>,
+    pressed_keys: HashSet<KeyCode>,
+    pressed_notes: HashSet<MusicalNote>,
+    master_volume: f64,
+    current_waveform: cuneus::gst::audio::AudioWaveform,
+}
+
+impl SynthManager {
+    fn handle_key_press(&mut self, keycode: KeyCode) -> bool {
+        if self.pressed_keys.contains(&keycode) {
+            return false;
+        }
+        
+        self.pressed_keys.insert(keycode);
+        
+        let note = match keycode {
+            KeyCode::Digit1 => Some(MusicalNote::C4),
+            KeyCode::Digit2 => Some(MusicalNote::D4),
+            KeyCode::Digit3 => Some(MusicalNote::E4),
+            KeyCode::Digit4 => Some(MusicalNote::F4),
+            KeyCode::Digit5 => Some(MusicalNote::G4),
+            KeyCode::Digit6 => Some(MusicalNote::A4),
+            KeyCode::Digit7 => Some(MusicalNote::B4),
+            KeyCode::Digit8 => Some(MusicalNote::C5),
+            KeyCode::Digit9 => Some(MusicalNote::CSharp4),
+            KeyCode::Space => {
+                if let Err(e) = self.audio_synth.stop_all_notes() {
+                    eprintln!("Failed to stop all notes: {}", e);
+                }
+                self.pressed_notes.clear();
+                return true;
+            },
+            KeyCode::ArrowUp => {
+                // Volume up
+                self.master_volume = (self.master_volume + 0.1).min(1.0);
+                if let Err(e) = self.audio_synth.set_master_volume(self.master_volume) {
+                    eprintln!("Failed to set master volume: {}", e);
+                }
+                info!("Master Volume: {:.1}%", self.master_volume * 100.0);
+                return true;
+            },
+            KeyCode::ArrowDown => {
+                // Volume down
+                self.master_volume = (self.master_volume - 0.1).max(0.0);
+                if let Err(e) = self.audio_synth.set_master_volume(self.master_volume) {
+                    eprintln!("Failed to set master volume: {}", e);
+                }
+                info!("Master Volume: {:.1}%", self.master_volume * 100.0);
+                return true;
+            },
+            _ => None,
+        };
+        
+        if let Some(note) = note {
+            if !self.pressed_notes.contains(&note) {
+                self.pressed_notes.insert(note);
+                if let Err(e) = self.audio_synth.play_note(note) {
+                    eprintln!("Failed to play note: {}", e);
+                } else {
+                    info!("Playing note: {} ({:.2} Hz)", note.name(), note.to_frequency());
+                }
+            }
+            return true;
+        }
+        
+        false
+    }
+    
+    fn handle_key_release(&mut self, keycode: KeyCode) -> bool {
+        if !self.pressed_keys.contains(&keycode) {
+            return false;
+        }
+        
+        self.pressed_keys.remove(&keycode);
+        
+        // Stop specific note when releasing note keys
+        let note = match keycode {
+            KeyCode::Digit1 => Some(MusicalNote::C4),
+            KeyCode::Digit2 => Some(MusicalNote::D4),
+            KeyCode::Digit3 => Some(MusicalNote::E4),
+            KeyCode::Digit4 => Some(MusicalNote::F4),
+            KeyCode::Digit5 => Some(MusicalNote::G4),
+            KeyCode::Digit6 => Some(MusicalNote::A4),
+            KeyCode::Digit7 => Some(MusicalNote::B4),
+            KeyCode::Digit8 => Some(MusicalNote::C5),
+            KeyCode::Digit9 => Some(MusicalNote::CSharp4),
+            _ => None,
+        };
+        
+        if let Some(note) = note {
+            if self.pressed_notes.contains(&note) {
+                self.pressed_notes.remove(&note);
+                if let Err(e) = self.audio_synth.stop_note(note) {
+                    eprintln!("Failed to stop note: {}", e);
+                } else {
+                    info!("Stopped note: {}", note.name());
+                }
+            }
+            return true;
+        }
+        
+        false
+    }
+    
+    fn update_audio_visualization(&mut self, queue: &wgpu::Queue) {
+        // Get current active notes and master volume
+        let active_notes = self.audio_synth.active_notes();
+        let master_volume = self.audio_synth.master_volume();
+        
+
+        self.audio_synth_uniform.data.update_from_synthesis(
+            &active_notes, 
+            master_volume, 
+            self.current_waveform
+        );
+        self.audio_synth_uniform.update(queue);
+    }
+}
+
+impl ShaderManager for SynthManager {
+    fn init(core: &Core) -> Self {
+        info!("Initializing audio synthesizer");
+        
+        // init audio synth
+        let mut audio_synth = AudioSynthManager::new(Some(44100))
+            .expect("Failed to create audio synthesis manager");
+        
+        if let Err(e) = audio_synth.start() {
+            eprintln!("Failed to start audio synthesis: {}", e);
+        }
+        
+        if let Err(e) = audio_synth.set_master_volume(0.3) {
+            eprintln!("Failed to set initial master volume: {}", e);
+        }
+        
+        let texture_bind_group_layout = core.device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("Texture Bind Group Layout"),
+            entries: &[
+                wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Texture {
+                        multisampled: false,
+                        sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                        view_dimension: wgpu::TextureViewDimension::D2,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                    count: None,
+                },
+            ],
+        });
+        
+        let mut base = RenderKit::new(
+            core,
+            include_str!("../../shaders/vertex.wgsl"),
+            include_str!("../../shaders/blit.wgsl"),
+            &[&texture_bind_group_layout],
+            None,
+        );
+        
+        let audio_synth_bind_group_layout = core.device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            entries: &[wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::COMPUTE,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Uniform,
+                    has_dynamic_offset: false,
+                    min_binding_size: None,
+                },
+                count: None,
+            }],
+            label: Some("audio_synth_bind_group_layout"),
+        });
+        
+        // Create audio synthesis uniform
+        let audio_synth_uniform = UniformBinding::new(
+            &core.device,
+            "Audio Synthesis Uniform",
+            AudioSynthUniform::new(),
+            &audio_synth_bind_group_layout,
+            0,
+        );
+
+        let config = ComputeShaderConfig {
+            workgroup_size: [16, 16, 1],
+            workgroup_count: None,
+            dispatch_once: false,
+            storage_texture_format: COMPUTE_TEXTURE_FORMAT_RGBA16,
+            enable_atomic_buffer: false,
+            atomic_buffer_multiples: 4,
+            entry_points: vec!["main".to_string()],
+            sampler_address_mode: wgpu::AddressMode::ClampToEdge,
+            sampler_filter_mode: wgpu::FilterMode::Linear,
+            label: "Audio Synthesizer Compute".to_string(),
+            mouse_bind_group_layout: Some(audio_synth_bind_group_layout.clone()),
+            enable_fonts: false,
+        };
+        
+        base.compute_shader = Some(cuneus::compute::ComputeShader::new_with_config(
+            core,
+            include_str!("../../shaders/synth.wgsl"),
+            config,
+        ));
+        
+        if let Some(compute_shader) = &mut base.compute_shader {
+            // Add the audio synthesis uniform binding as "mouse" uniform (bind group 2)
+            compute_shader.add_mouse_uniform_binding(&audio_synth_uniform.bind_group, 2);
+        }
+        
+        //hot reload
+        if let Some(compute_shader) = &mut base.compute_shader {
+            let shader_module = core.device.create_shader_module(wgpu::ShaderModuleDescriptor {
+                label: Some("Synth Compute Shader"),
+                source: wgpu::ShaderSource::Wgsl(include_str!("../../shaders/synth.wgsl").into()),
+            });
+            if let Err(e) = compute_shader.enable_hot_reload(
+                core.device.clone(),
+                PathBuf::from("shaders/synth.wgsl"),
+                shader_module,
+            ) {
+                eprintln!("Failed to enable compute shader hot reload: {}", e);
+            }
+        }
+        
+        
+        info!("Audio synthesizer initialized successfully");
+        info!("Controls:");
+        info!("  Keys 1-9: Play musical notes");
+        info!("  Space: Stop current note");
+        info!("  Arrow Up/Down: Volume up/down");
+        info!("  H: Toggle UI");
+        
+        Self {
+            base,
+            audio_synth,
+            audio_synth_uniform,
+            pressed_keys: HashSet::new(),
+            pressed_notes: HashSet::new(),
+            master_volume: 0.3,
+            current_waveform: cuneus::gst::audio::AudioWaveform::Sine,
+        }
+    }
+    
+    fn update(&mut self, core: &Core) {
+        self.base.fps_tracker.update();
+        self.audio_synth.update();
+        
+        self.update_audio_visualization(&core.queue);
+        
+        let current_time = self.base.controls.get_time(&self.base.start_time);
+        let delta = 1.0 / 60.0;
+        self.base.update_compute_shader_time(current_time, delta, &core.queue);
+    }
+    
+    fn render(&mut self, core: &Core) -> Result<(), wgpu::SurfaceError> {
+        let output = core.surface.get_current_texture()?;
+        let view = output.texture.create_view(&wgpu::TextureViewDescriptor::default());
+        
+        let mut controls_request = self.base.controls.get_ui_request(
+            &self.base.start_time,
+            &core.size
+        );
+        controls_request.current_fps = Some(self.base.fps_tracker.fps());
+        
+        let mut encoder = core.device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("Synth Render Encoder"),
+        });
+        
+        self.base.dispatch_compute_shader(&mut encoder, core);
+        
+        {
+            let mut render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("Main Render Pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: &view,
+                    resolve_target: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
+            });
+            
+            if let Some(compute_texture) = self.base.get_compute_output_texture() {
+                render_pass.set_pipeline(&self.base.renderer.render_pipeline);
+                render_pass.set_vertex_buffer(0, self.base.renderer.vertex_buffer.slice(..));
+                render_pass.set_bind_group(0, &compute_texture.bind_group, &[]);
+                render_pass.draw(0..4, 0..1);
+            }
+        }
+        
+        let active_notes = self.audio_synth.active_notes();
+        let master_volume = self.master_volume;
+        
+        let full_output = if self.base.key_handler.show_ui {
+            self.base.render_ui(core, |ctx| {
+                ctx.style_mut(|style| {
+                    style.visuals.window_fill = egui::Color32::from_rgba_premultiplied(0, 0, 0, 180);
+                    style.text_styles.get_mut(&egui::TextStyle::Body).unwrap().size = 11.0;
+                    style.text_styles.get_mut(&egui::TextStyle::Button).unwrap().size = 10.0;
+                });
+                
+                egui::Window::new("Audio Synthesizer")
+                    .collapsible(true)
+                    .resizable(true)
+                    .default_width(250.0)
+                    .show(ctx, |ui| {
+                        ui.heading("Audio Synthesizer");
+                        ui.separator();
+                        
+                        ShaderControls::render_controls_widget(ui, &mut controls_request);
+                        
+                        ui.separator();
+                        
+                        ui.label("Controls:");
+                        ui.label("• Keys 1-9: Play musical notes");
+                        ui.label("• Space: Stop current note");
+                        ui.label("• Arrow Up/Down: Volume up/down");
+                        ui.label("• H: Toggle this UI");
+                        
+                        ui.separator();
+                        
+                        ui.label("Waveform:");
+                        ui.horizontal(|ui| {
+                            if ui.radio_value(&mut self.current_waveform, cuneus::gst::audio::AudioWaveform::Sine, "Sine").changed() {
+                                let _ = self.audio_synth.set_waveform(cuneus::gst::audio::AudioWaveform::Sine);
+                            }
+                            if ui.radio_value(&mut self.current_waveform, cuneus::gst::audio::AudioWaveform::Square, "Square").changed() {
+                                let _ = self.audio_synth.set_waveform(cuneus::gst::audio::AudioWaveform::Square);
+                            }
+                            if ui.radio_value(&mut self.current_waveform, cuneus::gst::audio::AudioWaveform::Saw, "Saw").changed() {
+                                let _ = self.audio_synth.set_waveform(cuneus::gst::audio::AudioWaveform::Saw);
+                            }
+                            if ui.radio_value(&mut self.current_waveform, cuneus::gst::audio::AudioWaveform::Triangle, "Triangle").changed() {
+                                let _ = self.audio_synth.set_waveform(cuneus::gst::audio::AudioWaveform::Triangle);
+                            }
+                        });
+                        
+                        ui.separator();
+                        
+                        if !active_notes.is_empty() {
+                            ui.label("Active Notes:");
+                            for note in &active_notes {
+                                ui.label(format!("• {} ({:.2} Hz)", note.name(), note.to_frequency()));
+                            }
+                        } else {
+                            ui.label("Active Notes: None");
+                        }
+                        
+                        ui.separator();
+                        
+                        ui.label(format!("Master Volume: {:.1}%", master_volume * 100.0));
+                        ui.label(format!("Active Voices: {}", active_notes.len()));
+                    });
+            })
+        } else {
+            self.base.render_ui(core, |_ctx| {})
+        };
+        
+        self.base.apply_control_request(controls_request);
+        
+        self.base.handle_render_output(core, &view, full_output, &mut encoder);
+        core.queue.submit(Some(encoder.finish()));
+        output.present();
+        Ok(())
+    }
+    
+    fn resize(&mut self, core: &Core) {
+        self.base.update_resolution(&core.queue, core.size);
+        self.base.resize_compute_shader(core);
+    }
+    
+    fn handle_input(&mut self, core: &Core, event: &WindowEvent) -> bool {
+        let ui_handled = self.base.egui_state.on_window_event(core.window(), event).consumed;
+        
+        match event {
+            WindowEvent::KeyboardInput { event, .. } => {
+                if self.base.key_handler.handle_keyboard_input(core.window(), event) {
+                    return true;
+                }
+                
+                if !ui_handled {
+                    if let PhysicalKey::Code(keycode) = event.physical_key {
+                        match event.state {
+                            ElementState::Pressed => {
+                                return self.handle_key_press(keycode);
+                            },
+                            ElementState::Released => {
+                                return self.handle_key_release(keycode);
+                            },
+                        }
+                    }
+                }
+            },
+            _ => {},
+        }
+        
+        false
+    }
+}

--- a/src/gst/audio.rs
+++ b/src/gst/audio.rs
@@ -1,0 +1,605 @@
+use anyhow::{Result, anyhow};
+use gstreamer as gst;
+use log::{debug, info, warn};
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
+use gst::prelude::*;
+use gst::glib::ControlFlow;
+
+/// Individual audio voice for polyphonic synthesis
+/// Based: https://gstreamer.freedesktop.org/documentation/audiotestsrc/index.html?gi-language=c
+/// Sample rate: 44100
+struct AudioVoice {
+    /// The audiotestsrc element for this 'voice'
+    audiotestsrc: gst::Element,
+    /// The volume control element for this voice
+    volume: gst::Element,
+    /// Current frequency being generated
+    frequency: f64,
+    /// Current volume (0.0 to 1.0)
+    volume_level: f64,
+    /// Whether this voice is active
+    is_active: bool,
+    /// Musical note this voice is playing
+    note: Option<MusicalNote>,
+}
+
+/// Audio synthesis manager that can generate multiple tones simultaneously using GStreamer
+pub struct AudioSynthManager {
+    /// The GStreamer pipeline for audio generation
+    pipeline: gst::Pipeline,
+    /// The audio mixer element
+    _audiomixer: gst::Element,
+    /// Multiple voices for polyphonic synthesis
+    voices: Vec<AudioVoice>,
+    /// Current waveform type
+    current_waveform: AudioWaveform,
+    /// Master volume (0.0 to 1.0)
+    master_volume: Arc<Mutex<f64>>,
+    /// Sample rate for audio generation
+    sample_rate: u32,
+    /// Last update time
+    last_update: Instant,
+    /// Currently playing notes
+    active_notes: Arc<Mutex<Vec<MusicalNote>>>,
+}
+
+impl AudioSynthManager {
+    pub fn new(sample_rate: Option<u32>) -> Result<Self> {
+        let sample_rate = sample_rate.unwrap_or(44100);
+        // Support up to 8 simultaneous notes
+        let max_voices = 8;
+        
+        info!("Creating polyphonic audio synthesis manager with {} voices at {} Hz", max_voices, sample_rate);
+        
+        let pipeline = gst::Pipeline::new();
+        
+        // Create audio mixer for combining multiple voices
+        let audiomixer = gst::ElementFactory::make("audiomixer")
+            .name("audio_mixer")
+            .build()
+            .map_err(|_| anyhow!("Failed to create audiomixer element"))?;
+        
+        // Create final audio conversion and output chain
+        let final_convert = gst::ElementFactory::make("audioconvert")
+            .name("final_convert")
+            .build()
+            .map_err(|_| anyhow!("Failed to create final audioconvert element"))?;
+        
+        let final_resample = gst::ElementFactory::make("audioresample")
+            .name("final_resample")
+            .build()
+            .map_err(|_| anyhow!("Failed to create final audioresample element"))?;
+        
+        let master_volume = gst::ElementFactory::make("volume")
+            .name("master_volume")
+            .property("volume", 0.3f64)
+            .build()
+            .map_err(|_| anyhow!("Failed to create master volume element"))?;
+        
+        let audiosink = gst::ElementFactory::make("autoaudiosink")
+            .name("audio_sink")
+            .build()
+            .map_err(|_| anyhow!("Failed to create autoaudiosink element"))?;
+        
+        // A mixer and output chain to pipeline
+        pipeline.add_many(&[
+            &audiomixer,
+            &final_convert,
+            &final_resample,
+            &master_volume,
+            &audiosink,
+        ])
+        .map_err(|_| anyhow!("Failed to add output elements to pipeline"))?;
+        
+        gst::Element::link_many(&[
+            &audiomixer,
+            &final_convert,
+            &final_resample,
+            &master_volume,
+            &audiosink,
+        ])
+        .map_err(|_| anyhow!("Failed to link output elements"))?;
+        
+        // Create voices
+        let mut voices = Vec::new();
+        for i in 0..max_voices {
+            let voice = Self::create_voice(&pipeline, &audiomixer, i, sample_rate)?;
+            voices.push(voice);
+        }
+        
+        // bus watch for error handling stuff
+        let bus = pipeline.bus().expect("Pipeline has no bus");
+        let _ = bus.add_watch(move |_, message| {
+            match message.view() {
+                gst::MessageView::Error(err) => {
+                    warn!("Audio pipeline error: {} ({})", err.error(), err.debug().unwrap_or_default());
+                },
+                gst::MessageView::Warning(warning) => {
+                    debug!("Audio pipeline warning: {}", warning.error());
+                },
+                gst::MessageView::Eos(_) => {
+                    info!("Audio pipeline reached end of stream");
+                },
+                _ => (),
+            }
+            ControlFlow::Continue
+        });
+        
+        let audio_synth = Self {
+            pipeline,
+            _audiomixer: audiomixer,
+            voices,
+            current_waveform: AudioWaveform::Sine,
+            master_volume: Arc::new(Mutex::new(0.3)),
+            sample_rate,
+            last_update: Instant::now(),
+            active_notes: Arc::new(Mutex::new(Vec::new())),
+        };
+        
+        info!("Polyphonic audio synthesis manager created successfully");
+        Ok(audio_synth)
+    }
+    
+    fn create_voice(pipeline: &gst::Pipeline, mixer: &gst::Element, voice_id: usize, _sample_rate: u32) -> Result<AudioVoice> {
+        // Create audiotestsrc for this voice
+        let audiotestsrc = gst::ElementFactory::make("audiotestsrc")
+            .name(&format!("voice_{}_source", voice_id))
+            .property("freq", 440.0f64)
+            .property("volume", 0.0f64)  // Start silent
+            .property("samplesperbuffer", 512i32)
+            .property("is-live", true)
+            .build()
+            .map_err(|_| anyhow!("Failed to create audiotestsrc for voice {}", voice_id))?;
+        
+        //default waveform:
+        audiotestsrc.set_property_from_str("wave", "sine");
+        
+        // lets create voice-specific elements
+        let audioconvert = gst::ElementFactory::make("audioconvert")
+            .name(&format!("voice_{}_convert", voice_id))
+            .build()
+            .map_err(|_| anyhow!("Failed to create audioconvert for voice {}", voice_id))?;
+        
+        let audioresample = gst::ElementFactory::make("audioresample")
+            .name(&format!("voice_{}_resample", voice_id))
+            .build()
+            .map_err(|_| anyhow!("Failed to create audioresample for voice {}", voice_id))?;
+        
+        let volume = gst::ElementFactory::make("volume")
+            .name(&format!("voice_{}_volume", voice_id))
+            .property("volume", 0.0f64)
+            .build()
+            .map_err(|_| anyhow!("Failed to create volume for voice {}", voice_id))?;
+        
+        //voice elements to our pipeline...
+        pipeline.add_many(&[
+            &audiotestsrc,
+            &audioconvert,
+            &audioresample,
+            &volume,
+        ])
+        .map_err(|_| anyhow!("Failed to add voice {} elements to pipeline", voice_id))?;
+        
+        // link:
+        gst::Element::link_many(&[
+            &audiotestsrc,
+            &audioconvert,
+            &audioresample,
+            &volume,
+        ])
+        .map_err(|_| anyhow!("Failed to link voice {} elements", voice_id))?;
+        
+        // Connect to mixer
+        volume.link(mixer)
+            .map_err(|_| anyhow!("Failed to link voice {} to mixer", voice_id))?;
+        
+        Ok(AudioVoice {
+            audiotestsrc,
+            volume,
+            frequency: 440.0,
+            volume_level: 0.0,
+            is_active: false,
+            note: None,
+        })
+    }
+    
+    /// audio generation
+    pub fn start(&mut self) -> Result<()> {
+        info!("Starting polyphonic audio synthesis");
+        match self.pipeline.set_state(gst::State::Playing) {
+            Ok(_) => {
+                std::thread::sleep(std::time::Duration::from_millis(50));
+                Ok(())
+            },
+            Err(e) => Err(anyhow!("Failed to start audio synthesis: {:?}", e))
+        }
+    }
+    
+    // Stop all voices
+    pub fn stop(&mut self) -> Result<()> {
+        info!("Stopping audio synthesis");
+        for voice in &mut self.voices {
+            voice.volume.set_property("volume", 0.0f64);
+            voice.is_active = false;
+            voice.note = None;
+        }
+        self.active_notes.lock().unwrap().clear();
+        
+        match self.pipeline.set_state(gst::State::Null) {
+            Ok(_) => Ok(()),
+            Err(e) => Err(anyhow!("Failed to stop audio synthesis: {:?}", e))
+        }
+    }
+    
+    pub fn set_master_volume(&mut self, vol: f64) -> Result<()> {
+        let clamped_volume = vol.max(0.0).min(1.0);
+        *self.master_volume.lock().unwrap() = clamped_volume;
+        
+        // Find master volume element
+        if let Some(master_vol) = self.pipeline.by_name("master_volume") {
+            master_vol.set_property("volume", clamped_volume);
+        }
+        
+        debug!("Set master volume to {:.3}", clamped_volume);
+        Ok(())
+    }
+    
+    /// Set the waveform type for all voices
+    pub fn set_waveform(&mut self, wave_type: AudioWaveform) -> Result<()> {
+        let wave_str = match wave_type {
+            AudioWaveform::Sine => "sine",
+            AudioWaveform::Square => "square",
+            AudioWaveform::Saw => "saw",
+            AudioWaveform::Triangle => "triangle",
+        };
+        
+        self.current_waveform = wave_type;
+        
+        // Update all voices
+        for voice in &mut self.voices {
+            voice.audiotestsrc.set_property_from_str("wave", wave_str);
+        }
+        
+        debug!("Set waveform to {:?}", wave_type);
+        Ok(())
+    }
+    
+    /// Play a note (polyphonic - can play multiple notes simultaneously)
+    /// Little bit tricky, I tried to up to 8 notes at once 
+    pub fn play_note(&mut self, note: MusicalNote) -> Result<()> {
+        // Check if note is already playing
+        let mut active_notes = self.active_notes.lock().unwrap();
+        if active_notes.contains(&note) {
+            return Ok(()); // Note already playing
+        }
+        
+        // Find an available voice
+        if let Some(voice) = self.voices.iter_mut().find(|v| !v.is_active) {
+            let freq = note.to_frequency();
+            let volume_level = 0.4; // Individual voice volume
+            
+            // cfg voice
+            voice.audiotestsrc.set_property("freq", freq);
+            voice.audiotestsrc.set_property("volume", volume_level);
+            voice.volume.set_property("volume", volume_level);
+            voice.frequency = freq;
+            voice.volume_level = volume_level;
+            voice.is_active = true;
+            voice.note = Some(note);
+            
+            active_notes.push(note);
+            info!("Playing note {:?} ({:.2} Hz) on voice", note, freq);
+        } else {
+            warn!("No available voice for note {:?}", note);
+        }
+        
+        Ok(())
+    }
+
+    /// Stop a specific note. this more likely for testing purposes for myself
+    pub fn stop_note(&mut self, note: MusicalNote) -> Result<()> {
+        if let Some(voice) = self.voices.iter_mut().find(|v| v.note == Some(note)) {
+            voice.audiotestsrc.set_property("volume", 0.0f64);
+            voice.volume.set_property("volume", 0.0f64);
+            voice.is_active = false;
+            voice.note = None;
+            
+            // Remove from active notes
+            let mut active_notes = self.active_notes.lock().unwrap();
+            active_notes.retain(|&n| n != note);
+            
+            info!("Stopped note {:?}", note);
+        }
+        Ok(())
+    }
+    
+    pub fn stop_all_notes(&mut self) -> Result<()> {
+        for voice in &mut self.voices {
+            voice.audiotestsrc.set_property("volume", 0.0f64);
+            voice.volume.set_property("volume", 0.0f64);
+            voice.is_active = false;
+            voice.note = None;
+        }
+        self.active_notes.lock().unwrap().clear();
+        info!("Stopped all notes");
+        Ok(())
+    }
+    
+    /// Get current waveform
+    pub fn waveform(&self) -> AudioWaveform {
+        self.current_waveform
+    }
+    
+    /// Get master volume
+    pub fn master_volume(&self) -> f64 {
+        *self.master_volume.lock().unwrap()
+    }
+    
+    /// Check if any notes are playing
+    pub fn is_active(&self) -> bool {
+        !self.active_notes.lock().unwrap().is_empty()
+    }
+    
+    /// Get currently playing notes
+    pub fn active_notes(&self) -> Vec<MusicalNote> {
+        self.active_notes.lock().unwrap().clone()
+    }
+    
+    /// Get sample rate
+    pub fn sample_rate(&self) -> u32 {
+        self.sample_rate
+    }
+    
+    /// Update method to be called in the main loop if needed
+    pub fn update(&mut self) {
+        self.last_update = Instant::now();
+        //maybe per-frame updates?
+    }
+}
+
+impl Drop for AudioSynthManager {
+    fn drop(&mut self) {
+        info!("Shutting down audio synthesis pipeline");
+        let _ = self.pipeline.set_state(gst::State::Null);
+    }
+}
+
+/// Supported waveform types for audio synthesis
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AudioWaveform {
+    Sine,
+    Square,
+    Saw,
+    Triangle,
+}
+
+/// Musical notes with their frequencies
+/// I took these from here:
+/// https://www.liutaiomottola.com/formulae/freqtab.htm
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum MusicalNote {
+    C4,  // 261.63 Hz
+    CSharp4,  // 277.18 Hz
+    D4,  // 293.66 Hz
+    DSharp4,  // 311.13 Hz
+    E4,  // 329.63 Hz
+    F4,  // 349.23 Hz
+    FSharp4,  // 369.99 Hz
+    G4,  // 392.00 Hz
+    GSharp4,  // 415.30 Hz
+    A4,  // 440.00 Hz
+    ASharp4,  // 466.16 Hz
+    B4,  // 493.88 Hz
+    C5,  // 523.25 Hz
+}
+
+impl MusicalNote {
+    /// Convert musical note to frequency in Hz
+    pub fn to_frequency(self) -> f64 {
+        match self {
+            MusicalNote::C4 => 261.63,
+            MusicalNote::CSharp4 => 277.18,
+            MusicalNote::D4 => 293.66,
+            MusicalNote::DSharp4 => 311.13,
+            MusicalNote::E4 => 329.63,
+            MusicalNote::F4 => 349.23,
+            MusicalNote::FSharp4 => 369.99,
+            MusicalNote::G4 => 392.00,
+            MusicalNote::GSharp4 => 415.30,
+            MusicalNote::A4 => 440.00,
+            MusicalNote::ASharp4 => 466.16,
+            MusicalNote::B4 => 493.88,
+            MusicalNote::C5 => 523.25,
+        }
+    }
+    
+    /// Get note from keyboard number (1-9 maps to different notes)
+    pub fn from_keyboard_number(num: u32) -> Option<Self> {
+        match num {
+            1 => Some(MusicalNote::C4),
+            2 => Some(MusicalNote::D4),
+            3 => Some(MusicalNote::E4),
+            4 => Some(MusicalNote::F4),
+            5 => Some(MusicalNote::G4),
+            6 => Some(MusicalNote::A4),
+            7 => Some(MusicalNote::B4),
+            8 => Some(MusicalNote::C5),
+            9 => Some(MusicalNote::CSharp4),
+            _ => None,
+        }
+    }
+    
+    /// Get the name of the note as a string
+    pub fn name(self) -> &'static str {
+        match self {
+            MusicalNote::C4 => "C4",
+            MusicalNote::CSharp4 => "C#4",
+            MusicalNote::D4 => "D4",
+            MusicalNote::DSharp4 => "D#4",
+            MusicalNote::E4 => "E4",
+            MusicalNote::F4 => "F4",
+            MusicalNote::FSharp4 => "F#4",
+            MusicalNote::G4 => "G4",
+            MusicalNote::GSharp4 => "G#4",
+            MusicalNote::A4 => "A4",
+            MusicalNote::ASharp4 => "A#4",
+            MusicalNote::B4 => "B4",
+            MusicalNote::C5 => "C5",
+        }
+    }
+}
+
+/// Simple frequency-to-audio-data converter for visualization
+pub struct AudioDataProvider {
+    sample_count: usize,
+}
+
+impl AudioDataProvider {
+    pub fn new() -> Self {
+        Self {
+            sample_count: 0,
+        }
+    }
+    
+    /// Update with current audio synthesis parameters
+    pub fn update(&mut self, _active_notes: &[MusicalNote], _master_volume: f64) {
+        self.sample_count += 1;
+    }
+    
+    /// Generate audio data array for visualization based on active notes
+    /// Maps the 9 keyboard notes (1-9) directly to visualization data
+    pub fn generate_audio_data(&self, active_notes: &[MusicalNote], master_volume: f64) -> [[f32; 4]; 32] {
+        let mut audio_data = [[0.0f32; 4]; 32];
+        
+        // Map notes 1-9 to positions across the audio data array
+        // We'll use the first 9 positions to represent keys 1-9
+        let note_mapping = [
+            MusicalNote::C4,       // Key 1
+            MusicalNote::D4,       // Key 2
+            MusicalNote::E4,       // Key 3
+            MusicalNote::F4,       // Key 4
+            MusicalNote::G4,       // Key 5
+            MusicalNote::A4,       // Key 6
+            MusicalNote::B4,       // Key 7
+            MusicalNote::C5,       // Key 8
+            MusicalNote::CSharp4,  // Key 9
+        ];
+        
+        if master_volume > 0.0 {
+            // Check each of the 9 notes and set corresponding data
+            for (note_index, &mapped_note) in note_mapping.iter().enumerate() {
+                if active_notes.contains(&mapped_note) {
+                    // Calculate the position in the audio_data array for this note
+                    // Spread 9 notes across 32*4=128 positions
+                    let positions_per_note = 128 / 9; // ~14 positions per note
+                    let start_pos = note_index * positions_per_note;
+                    
+                    let amplitude = (master_volume * 0.9) as f32;
+                    
+                    // Fill multiple positions for this note to create a "region"
+                    for i in 0..positions_per_note.min(10) {
+                        let pos = start_pos + i;
+                        if pos < 128 {
+                            let array_index = pos / 4;
+                            let component_index = pos % 4;
+                            
+                            if array_index < 32 {
+                                // Create a peak with falloff from center
+                                let distance_from_center = (i as f32 - positions_per_note as f32 / 2.0).abs();
+                                let falloff = (1.0 - distance_from_center / (positions_per_note as f32 / 2.0)).max(0.0);
+                                let final_amplitude = amplitude * falloff;
+                                
+                                match component_index {
+                                    0 => audio_data[array_index][0] = (audio_data[array_index][0] + final_amplitude).min(1.0),
+                                    1 => audio_data[array_index][1] = (audio_data[array_index][1] + final_amplitude).min(1.0),
+                                    2 => audio_data[array_index][2] = (audio_data[array_index][2] + final_amplitude).min(1.0),
+                                    3 => audio_data[array_index][3] = (audio_data[array_index][3] + final_amplitude).min(1.0),
+                                    _ => {}
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        
+        audio_data
+    }
+}
+
+/// Dedicated uniform structure for audio synthesis data (separate from audio visualization)
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+pub struct AudioSynthUniform {
+    /// Active note frequencies (up to 16 simultaneous notes) - stored as vec4s for alignment
+    pub note_frequencies: [[f32; 4]; 4], // 16 frequencies in 4 vec4s
+    /// Individual note amplitudes - stored as vec4s for alignment  
+    pub note_amplitudes: [[f32; 4]; 4],  // 16 amplitudes in 4 vec4s
+    /// Master volume level
+    pub master_volume: f32,
+    /// Current waveform type (0=sine, 1=square, 2=saw, 3=triangle)
+    pub waveform_type: u32,
+    /// Number of currently active notes
+    pub active_note_count: u32,
+    /// Padding for proper alignment
+    pub _padding: u32,
+}
+
+// Safe to transmute to bytes for GPU upload
+unsafe impl bytemuck::Pod for AudioSynthUniform {}
+unsafe impl bytemuck::Zeroable for AudioSynthUniform {}
+
+impl crate::UniformProvider for AudioSynthUniform {
+    fn as_bytes(&self) -> &[u8] {
+        bytemuck::bytes_of(self)
+    }
+}
+
+impl AudioSynthUniform {
+    pub fn new() -> Self {
+        Self {
+            note_frequencies: [[0.0; 4]; 4],
+            note_amplitudes: [[0.0; 4]; 4],
+            master_volume: 0.0,
+            waveform_type: 0,
+            active_note_count: 0,
+            _padding: 0,
+        }
+    }
+    
+    /// Update with current synthesis state
+    pub fn update_from_synthesis(&mut self, active_notes: &[MusicalNote], master_volume: f64, waveform: AudioWaveform) {
+        // Clear previous data
+        for vec4 in &mut self.note_frequencies {
+            vec4.fill(0.0);
+        }
+        for vec4 in &mut self.note_amplitudes {
+            vec4.fill(0.0);
+        }
+        
+        // Update current state
+        self.master_volume = master_volume as f32;
+        self.waveform_type = match waveform {
+            AudioWaveform::Sine => 0,
+            AudioWaveform::Square => 1,
+            AudioWaveform::Saw => 2,
+            AudioWaveform::Triangle => 3,
+        };
+        self.active_note_count = active_notes.len().min(16) as u32;
+        
+        // Copy active note data (map 16 notes to 4 vec4s)
+        for (i, note) in active_notes.iter().take(16).enumerate() {
+            let vec4_index = i / 4;
+            let component_index = i % 4;
+            self.note_frequencies[vec4_index][component_index] = note.to_frequency() as f32;
+            self.note_amplitudes[vec4_index][component_index] = master_volume as f32;
+        }
+    }
+}
+
+impl Default for AudioDataProvider {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/gst/mod.rs
+++ b/src/gst/mod.rs
@@ -2,6 +2,8 @@
 pub mod video;
 #[cfg(feature = "media")]
 pub mod webcam;
+#[cfg(feature = "media")]
+pub mod audio;
 
 use log::info;
 


### PR DESCRIPTION
PR adds a complete polyphonic audio synthesis backend to Cuneus. 
 It uses only gstreamer: (`audiotestsrc`)
 https://gstreamer.freedesktop.org/documentation/audiotestsrc/index.html?gi-language=c
 
The synth backend includes polyphonic note generation. synthesizer example (still WIP) demonstrates keyboard-controlled musical notes (1-9), volume controls, waveform selection, and real-time compute shader visualization that responds directly to user input.

forms:
sine
square
saw
triangle