### PR TITLE
Add hot reload for 3dgs renderer on vertex/frag entry points

### DIFF
--- a/examples/gaussian3d.rs
+++ b/examples/gaussian3d.rs
@@ -221,11 +221,17 @@ impl ShaderManager for Gaussian3DShader {
             mapped_at_creation: false});
 
         let sorter = GaussianSorter::new_16bit(&core.device);
-        let renderer = GaussianRenderer::new(
+        let mut renderer = GaussianRenderer::new(
             &core.device,
             core.config.format,
             include_str!("shaders/gaussian3d.wgsl"),
         );
+        if let Err(e) = renderer.enable_hot_reload(
+            core.device.clone(),
+            std::path::PathBuf::from("examples/shaders/gaussian3d.wgsl"),
+        ) {
+            log::warn!("Failed to enable gaussian render hot reload: {e}");
+        }
 
         Self {
             base,
@@ -242,6 +248,7 @@ impl ShaderManager for Gaussian3DShader {
 
     fn update(&mut self, core: &Core) {
         self.preprocess.check_hot_reload(&core.device);
+        self.renderer.check_hot_reload(&core.device);
 
         if let Some((frame, time)) = self.base.export_manager.try_get_next_frame() {
             self.export_frame(core, frame, time);

--- a/src/gaussian.rs
+++ b/src/gaussian.rs
@@ -1,7 +1,9 @@
 use crate::compute::ComputeShader;
 use crate::radix_sort::RadixSorter;
-use crate::{Core, ExportSettings};
-use log::error;
+use crate::{Core, ExportSettings, ShaderHotReload};
+use log::{error, info};
+use std::path::PathBuf;
+use std::sync::Arc;
 
 /// GPU Sorter for Gaussian depth ordering
 pub struct GaussianSorter {
@@ -108,7 +110,10 @@ impl GaussianSorter {
 
 pub struct GaussianRenderer {
     pipeline: wgpu::RenderPipeline,
+    pipeline_layout: wgpu::PipelineLayout,
     bind_group_layout: wgpu::BindGroupLayout,
+    texture_format: wgpu::TextureFormat,
+    hot_reload: Option<ShaderHotReload>,
 }
 
 impl GaussianRenderer {
@@ -116,11 +121,6 @@ impl GaussianRenderer {
     ///
     /// The shader_source should contain `vs_main` and `fs_main` entry points.
     pub fn new(device: &wgpu::Device, texture_format: wgpu::TextureFormat, shader_source: &str) -> Self {
-        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
-            label: Some("Gaussian Render Shader"),
-            source: wgpu::ShaderSource::Wgsl(shader_source.into()),
-        });
-
         let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
             label: Some("Gaussian Render Bind Group Layout"),
             entries: &[
@@ -177,17 +177,47 @@ impl GaussianRenderer {
             immediate_size: 0,
         });
 
-        let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+        let pipeline = Self::build_pipeline(device, &pipeline_layout, texture_format, shader_source);
+
+        Self {
+            pipeline,
+            pipeline_layout,
+            bind_group_layout,
+            texture_format,
+            hot_reload: None,
+        }
+    }
+
+    fn build_pipeline(
+        device: &wgpu::Device,
+        pipeline_layout: &wgpu::PipelineLayout,
+        texture_format: wgpu::TextureFormat,
+        shader_source: &str,
+    ) -> wgpu::RenderPipeline {
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("Gaussian Render Shader"),
+            source: wgpu::ShaderSource::Wgsl(shader_source.into()),
+        });
+        Self::build_pipeline_from_module(device, pipeline_layout, texture_format, &shader)
+    }
+
+    fn build_pipeline_from_module(
+        device: &wgpu::Device,
+        pipeline_layout: &wgpu::PipelineLayout,
+        texture_format: wgpu::TextureFormat,
+        shader: &wgpu::ShaderModule,
+    ) -> wgpu::RenderPipeline {
+        device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
             label: Some("Gaussian Render Pipeline"),
-            layout: Some(&pipeline_layout),
+            layout: Some(pipeline_layout),
             vertex: wgpu::VertexState {
-                module: &shader,
+                module: shader,
                 entry_point: Some("vs_main"),
                 buffers: &[],
                 compilation_options: Default::default(),
             },
             fragment: Some(wgpu::FragmentState {
-                module: &shader,
+                module: shader,
                 entry_point: Some("fs_main"),
                 targets: &[Some(wgpu::ColorTargetState {
                     format: texture_format,
@@ -215,12 +245,45 @@ impl GaussianRenderer {
             multisample: wgpu::MultisampleState::default(),
             multiview_mask: None,
             cache: None,
-        });
+        })
+    }
 
-        Self {
-            pipeline,
-            bind_group_layout,
-        }
+    /// Watch `path` and recompile `vs_main`/`fs_main` on change. Call
+    /// `check_hot_reload` each frame to pick up edits.
+    pub fn enable_hot_reload(
+        &mut self,
+        device: Arc<wgpu::Device>,
+        path: PathBuf,
+    ) -> Result<(), notify::Error> {
+        let dummy = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("Gaussian Render Hot Reload Placeholder"),
+            source: wgpu::ShaderSource::Wgsl("".into()),
+        });
+        self.hot_reload = Some(ShaderHotReload::new_compute(
+            device,
+            path,
+            dummy,
+            "vs_main",
+        )?);
+        Ok(())
+    }
+
+
+    pub fn check_hot_reload(&mut self, device: &wgpu::Device) -> bool {
+        let Some(hot_reload) = &mut self.hot_reload else {
+            return false;
+        };
+        let Some(new_module) = hot_reload.reload_compute_shader() else {
+            return false;
+        };
+        self.pipeline = Self::build_pipeline_from_module(
+            device,
+            &self.pipeline_layout,
+            self.texture_format,
+            new_module,
+        );
+        info!("Gaussian render shader hot reloaded");
+        true
     }
 
     /// for rendering


### PR DESCRIPTION
 The compute pipeline goes through ComputeShader which has embeded  via our macro. But this is only for compute not frag/vertex entry. 
 with this fix I simply added hot patch on gs renderer but didnt want to add a macro just for that so only this one works:
 
         if let Err(e) = renderer.enable_hot_reload(
            core.device.clone(),
            std::path::PathBuf::from("examples/shaders/gaussian3d.wgsl"),
        ) {
            log::warn!("Failed to enable gaussian render hot reload: {e}");
        }