### PR TITLE
Frame accurate audio sync for export

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A GPU compute engine for creating, tweaking, and shipping WGSL shader programs. 
 - Audio/Visual synchronization: Spectrum and BPM detection
 - Real-time audio synthesis: Generate music directly from wgsl shaders
 - Export HQ frames via egui
+- Frame-accurate audio sync on export: pre analyzed spectrum/BPM per frame for perfect mux with the source audio
 
 ### Builder Pattern
 

--- a/src/compute/core.rs
+++ b/src/compute/core.rs
@@ -1745,6 +1745,21 @@ impl ComputeShader {
                     info!("Export: resizing compute from {}x{} to {}x{}", current_w, current_h, export_w, export_h);
                     self.resize(core, export_w, export_h);
                 }
+
+                // Run offline audio analysis (and audio extraction) up front so
+                // every captured frame can sample audio data at its own time.
+                #[cfg(feature = "media")]
+                {
+                    render_kit.begin_export_audio();
+                }
+            }
+
+            // Each frame: replace the live spectrum data with offline sampled
+            // data at this frame's media time, then push to the GPU buffer.
+            #[cfg(feature = "media")]
+            if render_kit.export_audio_active {
+                render_kit.apply_offline_audio_at(&core.queue, time as f64);
+                self.update_audio_spectrum(&render_kit.resolution_uniform.data, &core.queue);
             }
 
             match self.capture_export_frame(
@@ -1771,6 +1786,8 @@ impl ComputeShader {
                 info!("Export complete: resizing compute back to {}x{}", core.size.width, core.size.height);
                 self.resize(core, core.size.width, core.size.height);
             }
+            #[cfg(feature = "media")]
+            render_kit.end_export_audio();
             render_kit.export_manager.complete_export();
         }
     }
@@ -1796,6 +1813,17 @@ impl ComputeShader {
                     info!("Export: resizing compute from {}x{} to {}x{}", current_w, current_h, export_w, export_h);
                     self.resize(core, export_w, export_h);
                 }
+
+                #[cfg(feature = "media")]
+                {
+                    render_kit.begin_export_audio();
+                }
+            }
+
+            #[cfg(feature = "media")]
+            if render_kit.export_audio_active {
+                render_kit.apply_offline_audio_at(&core.queue, time as f64);
+                self.update_audio_spectrum(&render_kit.resolution_uniform.data, &core.queue);
             }
 
             match self.capture_export_frame(core, time, render_kit, Some(custom_dispatch)) {
@@ -1817,6 +1845,8 @@ impl ComputeShader {
                 info!("Export complete: resizing compute back to {}x{}", core.size.width, core.size.height);
                 self.resize(core, core.size.width, core.size.height);
             }
+            #[cfg(feature = "media")]
+            render_kit.end_export_audio();
             render_kit.export_manager.complete_export();
         }
     }

--- a/src/gst/mod.rs
+++ b/src/gst/mod.rs
@@ -1,6 +1,8 @@
 #[cfg(feature = "media")]
 pub mod audio;
 #[cfg(feature = "media")]
+pub mod offline_audio;
+#[cfg(feature = "media")]
 pub mod video;
 #[cfg(feature = "media")]
 pub mod webcam;

--- a/src/gst/offline_audio.rs
+++ b/src/gst/offline_audio.rs
@@ -1,0 +1,376 @@
+// Offline audio analysis for export.
+//
+// During the export, frames render at a different rate than realtime audio playback,
+// so the live spectrum/level/BPM data doesnt line up with the time of the
+// frame being captured. This module runs a non real time gst pipeline
+// (fakesink with sync=false) on the same src media to collect timestamped
+// spectrum/level/BPM events, which can then be looked up at frame time during
+// export and fed to the shader in place of the live data..
+
+use anyhow::{anyhow, Result};
+use gst::prelude::*;
+use gstreamer as gst;
+use log::{info, warn};
+use std::sync::{Arc, Mutex};
+
+#[derive(Debug, Clone)]
+pub struct SpectrumEvent {
+    pub time_secs: f64,
+    pub magnitudes: Vec<f32>,
+}
+
+#[derive(Debug, Clone)]
+pub struct LevelEvent {
+    pub time_secs: f64,
+    pub rms_db: f64,
+    pub peak: f64,
+}
+
+/// A complete offline analysis of an audio source: every spectrum/level event
+/// emitted, plus the final BPM the analyzer settled on.
+#[derive(Debug, Clone)]
+pub struct OfflineAudioAnalysis {
+    pub spectrum_events: Vec<SpectrumEvent>,
+    pub level_events: Vec<LevelEvent>,
+    pub bands: usize,
+    pub duration_secs: f64,
+    pub bpm: f32,
+}
+
+/// A point-in-time audio sample used by the spectrum analyzer's CPU-side
+/// processing. Lifetime borrows magnitudes from the parent analysis.
+pub struct AudioSample<'a> {
+    pub magnitudes: &'a [f32],
+    pub bands: usize,
+    pub rms_db: f64,
+    pub peak: f64,
+    pub bpm: f32,
+}
+
+impl OfflineAudioAnalysis {
+    /// Run a one shot gst pipeline at maximum speed to collect spectrum,
+    /// level, and BPM events. Blocks until EOS or error.
+    pub fn analyze(
+        media_path: &str,
+        bands: usize,
+        threshold_db: i32,
+        interval_ms: u64,
+    ) -> Result<Self> {
+        info!(
+            "Offline analysis starting: {} (bands={}, threshold={}dB, interval={}ms)",
+            media_path, bands, threshold_db, interval_ms
+        );
+
+        let pipeline = gst::Pipeline::new();
+
+        let filesrc = gst::ElementFactory::make("filesrc")
+            .name("source")
+            .property("location", media_path)
+            .build()
+            .map_err(|_| anyhow!("Failed to create filesrc"))?;
+
+        let decodebin = gst::ElementFactory::make("decodebin")
+            .name("decoder")
+            .build()
+            .map_err(|_| anyhow!("Failed to create decodebin"))?;
+
+        pipeline
+            .add_many([&filesrc, &decodebin])
+            .map_err(|_| anyhow!("Failed to add elements"))?;
+        gst::Element::link_many([&filesrc, &decodebin])
+            .map_err(|_| anyhow!("Failed to link filesrc to decodebin"))?;
+
+        let interval_ns = interval_ms * 1_000_000;
+        let pipeline_weak = pipeline.downgrade();
+        let audio_chain_built = Arc::new(Mutex::new(false));
+        let audio_chain_built_clone = audio_chain_built.clone();
+
+        decodebin.connect_pad_added(move |_, pad| {
+            let caps = match pad.current_caps() {
+                Some(c) => c,
+                None => return,
+            };
+            let structure = match caps.structure(0) {
+                Some(s) => s,
+                None => return,
+            };
+            if !structure.name().starts_with("audio/") {
+                return;
+            }
+
+            let mut built = audio_chain_built_clone.lock().unwrap();
+            if *built {
+                return;
+            }
+
+            let pipeline = match pipeline_weak.upgrade() {
+                Some(p) => p,
+                None => return,
+            };
+
+            let audioconvert = gst::ElementFactory::make("audioconvert")
+                .name("offline_audioconvert")
+                .build()
+                .expect("audioconvert");
+            let audioresample = gst::ElementFactory::make("audioresample")
+                .name("offline_audioresample")
+                .build()
+                .expect("audioresample");
+            let level = gst::ElementFactory::make("level")
+                .name("offline_level")
+                .property("interval", interval_ns)
+                .property("post-messages", true)
+                .build()
+                .expect("level");
+            let spectrum = gst::ElementFactory::make("spectrum")
+                .name("offline_spectrum")
+                .property("bands", bands as u32)
+                .property("threshold", threshold_db)
+                .property("post-messages", true)
+                .property("message-magnitude", true)
+                .property("message-phase", false)
+                .property("interval", interval_ns)
+                .build()
+                .expect("spectrum");
+            let bpmdetect = gst::ElementFactory::make("bpmdetect")
+                .name("offline_bpmdetect")
+                .build()
+                .expect("bpmdetect");
+            let fakesink = gst::ElementFactory::make("fakesink")
+                .name("offline_sink")
+                .property("sync", false)
+                .property("async", false)
+                .build()
+                .expect("fakesink");
+
+            pipeline
+                .add_many([
+                    &audioconvert,
+                    &audioresample,
+                    &level,
+                    &bpmdetect,
+                    &spectrum,
+                    &fakesink,
+                ])
+                .expect("add audio elements");
+
+            gst::Element::link_many([
+                &audioconvert,
+                &audioresample,
+                &level,
+                &bpmdetect,
+                &spectrum,
+                &fakesink,
+            ])
+            .expect("link audio elements");
+
+            let _ = audioconvert.sync_state_with_parent();
+            let _ = audioresample.sync_state_with_parent();
+            let _ = level.sync_state_with_parent();
+            let _ = bpmdetect.sync_state_with_parent();
+            let _ = spectrum.sync_state_with_parent();
+            let _ = fakesink.sync_state_with_parent();
+
+            let sink_pad = audioconvert
+                .static_pad("sink")
+                .expect("audioconvert sink pad");
+            if !sink_pad.is_linked() {
+                if let Err(e) = pad.link(&sink_pad) {
+                    warn!("Failed to link decoder to audioconvert: {e:?}");
+                    return;
+                }
+            }
+
+            *built = true;
+        });
+
+        pipeline
+            .set_state(gst::State::Playing)
+            .map_err(|e| anyhow!("Failed to start pipeline: {e:?}"))?;
+
+        let bus = pipeline.bus().ok_or_else(|| anyhow!("Pipeline has no bus"))?;
+
+        let mut spectrum_events: Vec<SpectrumEvent> = Vec::new();
+        let mut level_events: Vec<LevelEvent> = Vec::new();
+        let mut bpm: f32 = 0.0;
+        let mut last_event_time: f64 = 0.0;
+
+        for msg in bus.iter_timed(gst::ClockTime::from_seconds(60)) {
+            match msg.view() {
+                gst::MessageView::Eos(_) => {
+                    info!("Offline analysis: EOS reached");
+                    break;
+                }
+                gst::MessageView::Error(err) => {
+                    let _ = pipeline.set_state(gst::State::Null);
+                    return Err(anyhow!(
+                        "Offline analysis pipeline error: {} ({})",
+                        err.error(),
+                        err.debug().unwrap_or_default()
+                    ));
+                }
+                gst::MessageView::Element(element) => {
+                    if let Some(structure) = element.structure() {
+                        match structure.name().as_str() {
+                            "spectrum" => {
+                                let time_secs = structure
+                                    .get::<gst::ClockTime>("timestamp")
+                                    .map(|t| t.nseconds() as f64 / 1_000_000_000.0)
+                                    .unwrap_or(last_event_time);
+                                let mags = extract_magnitudes(structure);
+                                if !mags.is_empty() {
+                                    spectrum_events.push(SpectrumEvent {
+                                        time_secs,
+                                        magnitudes: mags,
+                                    });
+                                    last_event_time = time_secs;
+                                }
+                            }
+                            "level" => {
+                                let time_secs = structure
+                                    .get::<gst::ClockTime>("timestamp")
+                                    .map(|t| t.nseconds() as f64 / 1_000_000_000.0)
+                                    .unwrap_or(last_event_time);
+                                if let Some((rms_db, peak)) = extract_level(structure) {
+                                    level_events.push(LevelEvent {
+                                        time_secs,
+                                        rms_db,
+                                        peak,
+                                    });
+                                    last_event_time = time_secs;
+                                }
+                            }
+                            "tempo" => {
+                                if let Ok(val) = structure.get::<f64>("tempo") {
+                                    if val > 0.0 {
+                                        bpm = val as f32;
+                                    }
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+                gst::MessageView::Tag(tag) => {
+                    if let Some(b) = tag.tags().get::<gst::tags::BeatsPerMinute>() {
+                        let v = b.get() as f32;
+                        if v > 0.0 {
+                            bpm = v;
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        pipeline
+            .set_state(gst::State::Null)
+            .map_err(|e| anyhow!("Failed to stop pipeline: {e:?}"))?;
+
+        let duration_secs = spectrum_events
+            .last()
+            .map(|e| e.time_secs)
+            .unwrap_or(last_event_time);
+
+        info!(
+            "Offline analysis done: {} spectrum events, {} level events, duration {:.2}s, BPM={:.1}",
+            spectrum_events.len(),
+            level_events.len(),
+            duration_secs,
+            bpm
+        );
+
+        if spectrum_events.is_empty() {
+            return Err(anyhow!(
+                "Offline analysis collected no spectrum events; source may have no audio track"
+            ));
+        }
+
+        Ok(Self {
+            spectrum_events,
+            level_events,
+            bands,
+            duration_secs,
+            bpm,
+        })
+    }
+
+    /// Returns the latest spectrum/level pair at or before `time_secs`. If
+    /// `time_secs` is before any data, returns the first event.
+    pub fn sample(&self, time_secs: f64) -> Option<AudioSample<'_>> {
+        let spec = latest_at_or_before(&self.spectrum_events, time_secs, |e| e.time_secs)?;
+        let lev = latest_at_or_before(&self.level_events, time_secs, |e| e.time_secs);
+        Some(AudioSample {
+            magnitudes: &spec.magnitudes,
+            bands: self.bands,
+            rms_db: lev.map(|l| l.rms_db).unwrap_or(-100.0),
+            peak: lev.map(|l| l.peak).unwrap_or(0.0),
+            bpm: self.bpm,
+        })
+    }
+}
+
+fn extract_magnitudes(structure: &gst::StructureRef) -> Vec<f32> {
+    // The spectrum element exposes magnitude as an array typed field. the
+    // existing live path falls back to string parsing because the typed
+    // accessor returned NotFound on some platforms. We try both.
+    let mut out: Vec<f32> = Vec::new();
+
+    let s = structure.to_string();
+    if let Some(start_idx) = s.find("magnitude=(float){") {
+        if let Some(end_rel) = s[start_idx..].find('}') {
+            let inner = &s[start_idx + "magnitude=(float){".len()..start_idx + end_rel];
+            for tok in inner.split(',') {
+                if let Ok(v) = tok.trim().parse::<f32>() {
+                    out.push(v);
+                }
+            }
+        }
+    }
+
+    if out.is_empty() {
+        for i in 0..1024 {
+            let field = format!("magnitude[{i}]");
+            match structure.get::<f32>(&field) {
+                Ok(v) => out.push(v),
+                Err(_) => break,
+            }
+        }
+    }
+
+    out
+}
+
+fn extract_level(structure: &gst::StructureRef) -> Option<(f64, f64)> {
+    let rms_list = structure.get::<gst::glib::ValueArray>("rms").ok()?;
+    let peak_list = structure.get::<gst::glib::ValueArray>("peak").ok()?;
+    let rms_db = rms_list.iter().next()?.get::<f64>().ok()?;
+    let peak_db = peak_list.iter().next()?.get::<f64>().ok()?;
+    let peak_linear = 10.0_f64.powf(peak_db / 20.0);
+    Some((rms_db, peak_linear))
+}
+
+fn latest_at_or_before<T, F>(events: &[T], time_secs: f64, key: F) -> Option<&T>
+where
+    F: Fn(&T) -> f64,
+{
+    if events.is_empty() {
+        return None;
+    }
+    let mut lo = 0usize;
+    let mut hi = events.len();
+    while lo < hi {
+        let mid = (lo + hi) / 2;
+        if key(&events[mid]) <= time_secs {
+            lo = mid + 1;
+        } else {
+            hi = mid;
+        }
+    }
+    if lo == 0 {
+        events.first()
+    } else {
+        events.get(lo - 1)
+    }
+}
+

--- a/src/renderkit.rs
+++ b/src/renderkit.rs
@@ -64,6 +64,10 @@ pub struct RenderKit {
     pub export_manager: ExportManager,
     pub controls: ShaderControls,
     pub spectrum_analyzer: SpectrumAnalyzer,
+    #[cfg(feature = "media")]
+    pub offline_audio_analysis: Option<crate::gst::offline_audio::OfflineAudioAnalysis>,
+    #[cfg(feature = "media")]
+    pub export_audio_active: bool,
     pub compute_shader: Option<ComputeShader>,
     pub fps_tracker: fps::FpsTracker,
     pub mouse_tracker: MouseTracker,
@@ -221,6 +225,10 @@ impl RenderKit {
             export_manager: ExportManager::new(),
             controls: ShaderControls::new(),
             spectrum_analyzer: SpectrumAnalyzer::new(),
+            #[cfg(feature = "media")]
+            offline_audio_analysis: None,
+            #[cfg(feature = "media")]
+            export_audio_active: false,
             compute_shader: None,
             fps_tracker,
             mouse_tracker,
@@ -723,12 +731,89 @@ impl RenderKit {
     }
     #[cfg(feature = "media")]
     pub fn update_audio_spectrum(&mut self, queue: &wgpu::Queue) {
+        // During export, audio is driven by handle_export per-frame from the
+        // offline analysis so the spectrum lines up with the time of the frame
+        // being captured. Skip the live path to avoid clobbering that data.
+        if self.export_audio_active {
+            return;
+        }
         self.spectrum_analyzer.update_spectrum(
             queue,
             &mut self.resolution_uniform,
             &self.video_texture_manager,
             self.using_video_texture,
         );
+    }
+
+    /// Feed a single offline analyzed audio frame (looked up at media time
+    /// `time_secs`) into the spectrum analyzer's processing pipeline. Used by
+    /// the export path so each rendered frame sees audio data sampled at its
+    /// own timeline position rather than wherever live playback happens to be.
+    #[cfg(feature = "media")]
+    pub fn apply_offline_audio_at(&mut self, queue: &wgpu::Queue, time_secs: f64) {
+        if let Some(analysis) = &self.offline_audio_analysis {
+            if let Some(sample) = analysis.sample(time_secs) {
+                self.spectrum_analyzer.apply_offline_sample(
+                    queue,
+                    &mut self.resolution_uniform,
+                    &sample,
+                );
+            }
+        }
+    }
+
+    /// Run the offline audio analyzer for the currently loaded media file so
+    /// the export path can sample frame-time-aligned spectrum/level/BPM data.
+    /// Called once at the start of export. Returns true if analysis succeeded.
+    #[cfg(feature = "media")]
+    pub fn begin_export_audio(&mut self) -> bool {
+        let path_opt = self
+            .video_texture_manager
+            .as_ref()
+            .filter(|vm| vm.has_audio())
+            .map(|vm| vm.path().to_owned());
+        let media_path = match path_opt {
+            Some(p) => p,
+            None => return false,
+        };
+
+        // Pause live playback so its bus traffic doesn't compete with the
+        // offline pipeline and so the user doesn't hear audio drift while
+        // export runs.
+        let _ = self.pause_video();
+        self.spectrum_analyzer.reset_smoothing();
+
+        info!("Pre-analyzing audio for export: {}", media_path);
+        match crate::gst::offline_audio::OfflineAudioAnalysis::analyze(
+            &media_path, 128, -60, 50,
+        ) {
+            Ok(analysis) => {
+                self.offline_audio_analysis = Some(analysis);
+                self.export_audio_active = true;
+                true
+            }
+            Err(e) => {
+                error!("Offline audio analysis failed: {e}");
+                self.offline_audio_analysis = None;
+                self.export_audio_active = false;
+                let _ = self.play_video();
+                false
+            }
+        }
+    }
+
+    /// Drop any offline analysis state and resume live playback. Called when
+    /// export finishes.
+    #[cfg(feature = "media")]
+    pub fn end_export_audio(&mut self) {
+        if self.offline_audio_analysis.is_some() {
+            self.offline_audio_analysis = None;
+        }
+        if self.export_audio_active {
+            self.export_audio_active = false;
+            self.spectrum_analyzer.reset_smoothing();
+            let _ = self.play_video();
+        }
     }
     #[cfg(feature = "media")]
     pub fn handle_video_requests(&mut self, core: &Core, request: &ControlsRequest) {

--- a/src/spectrum.rs
+++ b/src/spectrum.rs
@@ -1,6 +1,8 @@
 // This file is part of the gstreamer, and its inits the spectrum analyzer and bpm.
 // I also did some smoothing related to audio data for the spectrum analyzer.
 #[cfg(feature = "media")]
+use crate::gst::offline_audio::AudioSample;
+#[cfg(feature = "media")]
 use crate::gst::video::VideoTextureManager;
 #[cfg(feature = "media")]
 use crate::ResolutionUniform;
@@ -29,6 +31,13 @@ impl SpectrumAnalyzer {
         }
     }
 
+    /// Reset per-band smoothing state. Called at export start/end so that
+    /// transitions between live and offline data don't leak through the
+    /// attack/decay filter.
+    pub fn reset_smoothing(&mut self) {
+        self.prev_audio_data = [[0.0; 4]; 32];
+    }
+
     pub fn update_spectrum(
         &mut self,
         queue: &wgpu::Queue,
@@ -48,171 +57,191 @@ impl SpectrumAnalyzer {
                 if video_manager.has_audio() {
                     let spectrum_data = video_manager.spectrum_data();
                     let audio_level = video_manager.audio_level();
-                    resolution_uniform.data.bpm = video_manager.get_bpm();
+                    let bpm = video_manager.get_bpm();
 
                     if !spectrum_data.magnitudes.is_empty() {
-                        let bands = spectrum_data.bands;
-                        // Highly sensitive threshold for detecting subtle high frequencies
-                        let threshold: f32 = -60.0;
-
-                        // Calculate adaptive gain based on RMS
-                        // Target RMS: -20dB (moderate loudness)
-                        // Loud songs (metal): RMS ~ -10dB → gain < 1.0 (reduce)
-                        // Quiet songs: RMS ~ -30dB → gain > 1.0 (boost)
-                        let target_rms_db = -20.0;
-                        let current_rms_db = audio_level.rms_db as f32;
-                        let adaptive_gain = if current_rms_db > -100.0 {
-                            // Calculate gain to bring current RMS closer to target
-                            let db_diff = target_rms_db - current_rms_db;
-                            // Convert dB difference to linear gain (every 6dB ≈ 2x amplitude)
-                            let gain = 10.0_f32.powf(db_diff / 20.0);
-                            // Clamp to reasonable range (0.3 to 3.0)
-                            gain.max(0.3).min(3.0)
-                        } else {
-                            1.0 // No adjustment if RMS is invalid
-                        };
-
-                        // sanity: to see RMS normalization values
-                        info!(
-                            "Audio Level - RMS: {:.2}dB, Peak: {:.3}, Gain: {:.2}x",
-                            current_rms_db, audio_level.peak, adaptive_gain
+                        self.process_audio_sample(
+                            resolution_uniform,
+                            &spectrum_data.magnitudes,
+                            spectrum_data.bands,
+                            audio_level.rms_db as f32,
+                            bpm,
+                            /* log_live = */ true,
                         );
-
-                        // Process only first 64 bands (note that, we actually have 128 but its expensiive)
-                        for i in 0..64 {
-                            let band_percent = i as f32 / 64.0;
-                            // Map to source index with slight emphasis on higher frequencies
-                            let source_idx = (band_percent * (bands as f32 / 2.0)) as usize;
-                            // Use narrow width for all frequencies for accuracy
-                            let width = 1;
-                            let end_idx = (source_idx + width).min(bands);
-
-                            if source_idx < bands {
-                                // Get peak value in this range
-                                let mut peak: f32 = -120.0;
-                                for j in source_idx..end_idx {
-                                    if j < bands {
-                                        let val = spectrum_data.magnitudes[j];
-                                        peak = peak.max(val);
-                                    }
-                                }
-                                // Map from dB scale to 0-1
-                                let mut normalized =
-                                    ((peak - threshold) / -threshold).max(0.0).min(1.0);
-                                normalized = (normalized * adaptive_gain).min(1.0);
-                                // Apply frequency-specific processing that's balanced
-                                // Lower boost for bass, higher boost for treble
-                                let enhanced = if band_percent < 0.2 {
-                                    // Bass - slightly reduced
-                                    (normalized.powf(0.75) * 0.85).min(1.0)
-                                } else if band_percent < 0.4 {
-                                    // Low-mids - neutral
-                                    normalized.powf(0.7).min(1.0)
-                                } else if band_percent < 0.6 {
-                                    // Mids - slight boost
-                                    (normalized.powf(0.65) * 1.1).min(1.0)
-                                } else if band_percent < 0.8 {
-                                    // Upper-mids - moderate boost
-                                    (normalized.powf(0.55) * 1.6).min(1.0)
-                                } else {
-                                    // Highs - significant boost with lower power
-                                    // The critical adjustment for high frequency sensitivity
-                                    (normalized.powf(0.4) * 3.0).min(1.0)
-                                };
-
-                                // No minimum thresholds - let silent frequencies be silent
-                                // Temporal smoothing with frequency-specific parameters
-                                let vec_idx = i / 4;
-                                let vec_component = i % 4;
-                                if vec_idx < 32 {
-                                    let prev_value = self.prev_audio_data[vec_idx][vec_component];
-                                    // Fast attack for all frequencies - slightly faster for highs
-                                    let attack = if band_percent < 0.6 { 0.6 } else { 0.7 };
-                                    let decay = if band_percent < 0.6 { 0.3 } else { 0.25 };
-
-                                    // Apply smoothing
-                                    let smoothing_factor = if enhanced > prev_value {
-                                        attack // Rising
-                                    } else {
-                                        decay // Falling
-                                    };
-                                    // Calculate smoothed value
-                                    let smoothed = prev_value * (1.0 - smoothing_factor)
-                                        + enhanced * smoothing_factor;
-                                    // Store the result
-                                    resolution_uniform.data.audio_data[vec_idx][vec_component] =
-                                        smoothed;
-                                    // Store for next frame
-                                    self.prev_audio_data[vec_idx][vec_component] = smoothed;
-                                }
-                            }
-                        }
-
-                        // Compute audio energy for bass/mid/high ranges
-                        let mut bass_sum = 0.0f32;
-                        let mut mid_sum = 0.0f32;
-                        let mut high_sum = 0.0f32;
-
-                        for i in 0..64 {
-                            let vec_idx = i / 4;
-                            let component = i % 4;
-                            let value = resolution_uniform.data.audio_data[vec_idx][component];
-
-                            let freq = i as f32 / 64.0;
-                            if freq < 0.2 {
-                                bass_sum += value;
-                            } else if freq < 0.6 {
-                                mid_sum += value;
-                            } else {
-                                high_sum += value;
-                            }
-                        }
-
-                        // Normalize by band count
-                        let bass_energy = bass_sum / 13.0; // bands 0-12
-                        let mid_energy = mid_sum / 26.0;   // bands 13-38
-                        let high_energy = high_sum / 25.0; // bands 39-63
-                        let total_energy = (bass_energy * 1.5 + mid_energy + high_energy) / 3.5;
-
-                        // Store in resolution uniform for shaders to access
-                        resolution_uniform.data.bass_energy = bass_energy;
-                        resolution_uniform.data.mid_energy = mid_energy;
-                        resolution_uniform.data.high_energy = high_energy;
-                        resolution_uniform.data.total_energy = total_energy;
-
-                        // If we detect a beat, provide progressive boost to mid/high frequencies
-                        if bass_energy > 0.5 {
-                            // First quarter - bass
-                            let q1 = 16 / 4;
-                            // Second quarter - low-mids
-                            let q2 = 16 / 2;
-                            // Third quarter - upper-mids
-                            let q3 = 3 * 16 / 4;
-
-                            for i in 0..16 {
-                                for j in 0..4 {
-                                    if i < q1 {
-                                        // No boost for bass (prevent dominance)
-                                        // Actually reduce bass slightly on beats
-                                        resolution_uniform.data.audio_data[i][j] *= 0.9;
-                                    } else if i < q2 {
-                                        // Small boost for low-mids
-                                        resolution_uniform.data.audio_data[i][j] *= 1.1;
-                                    } else if i < q3 {
-                                        // Moderate boost for upper-mids
-                                        resolution_uniform.data.audio_data[i][j] *= 1.3;
-                                    } else {
-                                        // Strong boost for highs during beats
-                                        resolution_uniform.data.audio_data[i][j] *= 1.7;
-                                    }
-                                }
-                            }
-                        }
                     }
                 }
             }
 
             resolution_uniform.update(queue);
+        }
+    }
+
+    /// Offline path: feed a single timestamped sample collected by the offline
+    /// analyzer into the same processing pipeline that live updates use, so the
+    /// visual output is identical between preview and export.
+    pub fn apply_offline_sample(
+        &mut self,
+        queue: &wgpu::Queue,
+        resolution_uniform: &mut UniformBinding<ResolutionUniform>,
+        sample: &AudioSample<'_>,
+    ) {
+        for i in 0..32 {
+            for j in 0..4 {
+                resolution_uniform.data.audio_data[i][j] = 0.0;
+            }
+        }
+
+        self.process_audio_sample(
+            resolution_uniform,
+            sample.magnitudes,
+            sample.bands,
+            sample.rms_db as f32,
+            sample.bpm,
+            /* log_live = */ false,
+        );
+
+        resolution_uniform.update(queue);
+    }
+
+    /// Shared audio processing used by both the live and offline paths.
+    /// Reads raw spectrum magnitudes (dB scale) and writes normalized,
+    /// frequency-shaped, attack/decay-smoothed values into the resolution
+    /// uniform, plus computed bass/mid/high/total energies and BPM.
+    fn process_audio_sample(
+        &mut self,
+        resolution_uniform: &mut UniformBinding<ResolutionUniform>,
+        magnitudes: &[f32],
+        bands: usize,
+        rms_db: f32,
+        bpm: f32,
+        log_live: bool,
+    ) {
+        resolution_uniform.data.bpm = bpm;
+
+        // Highly sensitive threshold for detecting subtle high frequencies
+        let threshold: f32 = -60.0;
+
+        // Calculate adaptive gain based on RMS
+        // Target RMS: -20dB (moderate loudness)
+        let target_rms_db = -20.0;
+        let adaptive_gain = if rms_db > -100.0 {
+            let db_diff = target_rms_db - rms_db;
+            let gain = 10.0_f32.powf(db_diff / 20.0);
+            gain.max(0.3).min(3.0)
+        } else {
+            1.0
+        };
+
+        if log_live {
+            info!(
+                "Audio Level - RMS: {:.2}dB, Gain: {:.2}x",
+                rms_db, adaptive_gain
+            );
+        }
+
+        // Process only first 64 bands (we typically have 128 but its expensive)
+        for i in 0..64 {
+            let band_percent = i as f32 / 64.0;
+            // Map to source index with slight emphasis on higher frequencies
+            let source_idx = (band_percent * (bands as f32 / 2.0)) as usize;
+            let width = 1;
+            let end_idx = (source_idx + width).min(bands);
+
+            if source_idx < bands {
+                let mut peak: f32 = -120.0;
+                for j in source_idx..end_idx {
+                    if j < bands {
+                        let val = magnitudes[j];
+                        peak = peak.max(val);
+                    }
+                }
+                // Map from dB scale to 0-1
+                let mut normalized = ((peak - threshold) / -threshold).max(0.0).min(1.0);
+                normalized = (normalized * adaptive_gain).min(1.0);
+                // Frequency-specific processing
+                let enhanced = if band_percent < 0.2 {
+                    // Bass - slightly reduced
+                    (normalized.powf(0.75) * 0.85).min(1.0)
+                } else if band_percent < 0.4 {
+                    // Low-mids - neutral
+                    normalized.powf(0.7).min(1.0)
+                } else if band_percent < 0.6 {
+                    // Mids - slight boost
+                    (normalized.powf(0.65) * 1.1).min(1.0)
+                } else if band_percent < 0.8 {
+                    // Upper-mids - moderate boost
+                    (normalized.powf(0.55) * 1.6).min(1.0)
+                } else {
+                    // Highs - significant boost with lower power
+                    (normalized.powf(0.4) * 3.0).min(1.0)
+                };
+
+                // Temporal smoothing with frequency-specific parameters
+                let vec_idx = i / 4;
+                let vec_component = i % 4;
+                if vec_idx < 32 {
+                    let prev_value = self.prev_audio_data[vec_idx][vec_component];
+                    let attack = if band_percent < 0.6 { 0.6 } else { 0.7 };
+                    let decay = if band_percent < 0.6 { 0.3 } else { 0.25 };
+
+                    let smoothing_factor = if enhanced > prev_value { attack } else { decay };
+                    let smoothed =
+                        prev_value * (1.0 - smoothing_factor) + enhanced * smoothing_factor;
+                    resolution_uniform.data.audio_data[vec_idx][vec_component] = smoothed;
+                    self.prev_audio_data[vec_idx][vec_component] = smoothed;
+                }
+            }
+        }
+
+        // Compute audio energy for bass/mid/high ranges
+        let mut bass_sum = 0.0f32;
+        let mut mid_sum = 0.0f32;
+        let mut high_sum = 0.0f32;
+
+        for i in 0..64 {
+            let vec_idx = i / 4;
+            let component = i % 4;
+            let value = resolution_uniform.data.audio_data[vec_idx][component];
+
+            let freq = i as f32 / 64.0;
+            if freq < 0.2 {
+                bass_sum += value;
+            } else if freq < 0.6 {
+                mid_sum += value;
+            } else {
+                high_sum += value;
+            }
+        }
+
+        let bass_energy = bass_sum / 13.0;
+        let mid_energy = mid_sum / 26.0;
+        let high_energy = high_sum / 25.0;
+        let total_energy = (bass_energy * 1.5 + mid_energy + high_energy) / 3.5;
+
+        resolution_uniform.data.bass_energy = bass_energy;
+        resolution_uniform.data.mid_energy = mid_energy;
+        resolution_uniform.data.high_energy = high_energy;
+        resolution_uniform.data.total_energy = total_energy;
+
+        // If we detect a beat, provide progressive boost to mid/high frequencies
+        if bass_energy > 0.5 {
+            let q1 = 16 / 4;
+            let q2 = 16 / 2;
+            let q3 = 3 * 16 / 4;
+
+            for i in 0..16 {
+                for j in 0..4 {
+                    if i < q1 {
+                        resolution_uniform.data.audio_data[i][j] *= 0.9;
+                    } else if i < q2 {
+                        resolution_uniform.data.audio_data[i][j] *= 1.1;
+                    } else if i < q3 {
+                        resolution_uniform.data.audio_data[i][j] *= 1.3;
+                    } else {
+                        resolution_uniform.data.audio_data[i][j] *= 1.7;
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Adds an offline audio analysis pass that runs on the source media before export starts, so each captured frame samples spectrum/level/BPM data at its own timeline position instead of wherever live playback happens to be. For users: exported audio visualizers now line up perfectly with the original audio when muxed in ffmpeg, regardless of export resolution or render speed.

