### PR TITLE
feat(capi): add remote parameter control for cuneus bins

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ readme = "readme.md"
 keywords = ["graphics", "wgpu", "shaders", "gpu"]
 categories = ["graphics", "rendering"]
 
+[lib]
+crate-type = ["rlib", "cdylib"]
+
 [dependencies]
 wgpu = "24.0.1"
 winit = "0.30.11"

--- a/include/cuneus.h
+++ b/include/cuneus.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <stdint.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct CuneusInstance CuneusInstance;
+
+typedef enum CuneusStatus {
+    CUNEUS_STATUS_OK = 0,
+    CUNEUS_STATUS_NULL = 1,
+    CUNEUS_STATUS_INVALID_ARGUMENT = 2,
+    CUNEUS_STATUS_NOT_FOUND = 3,
+    CUNEUS_STATUS_IO_ERROR = 4,
+} CuneusStatus;
+
+typedef enum CuneusParamType {
+    CUNEUS_PARAM_F32 = 0,
+    CUNEUS_PARAM_COLOR3 = 1,
+} CuneusParamType;
+
+typedef struct CuneusParamDesc {
+    const char* id;
+    const char* label;
+    CuneusParamType param_type;
+    float min_value;
+    float max_value;
+    float default_value;
+    uint32_t flags;
+} CuneusParamDesc;
+
+size_t cuneus_bin_count(void);
+const char* cuneus_bin_name(size_t index);
+
+CuneusInstance* cuneus_instance_open(const char* bin_name, const char* executable_dir, uint16_t remote_port);
+void cuneus_instance_free(CuneusInstance* instance);
+
+const char* cuneus_last_error(void);
+
+size_t cuneus_param_count(CuneusInstance* instance);
+CuneusStatus cuneus_param_desc(CuneusInstance* instance, size_t index, CuneusParamDesc* out_desc);
+CuneusStatus cuneus_set_param_f32(CuneusInstance* instance, const char* id, float value);
+CuneusStatus cuneus_set_param_color3(CuneusInstance* instance, const char* id, float r, float g, float b);
+CuneusStatus cuneus_pulse(CuneusInstance* instance, float velocity);
+CuneusStatus cuneus_note(CuneusInstance* instance, float pitch, float velocity);
+CuneusStatus cuneus_set_transport(CuneusInstance* instance, float bpm, float beat, float measure);
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/cuneus_capi.h
+++ b/include/cuneus_capi.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#include "cuneus.h"

--- a/src/bin/roto.rs
+++ b/src/bin/roto.rs
@@ -1,4 +1,4 @@
-use cuneus::{Core,Renderer,ShaderApp, ShaderManager, UniformProvider, UniformBinding, RenderKit,ExportManager,ShaderHotReload,ShaderControls};
+use cuneus::{Core,Renderer,ShaderApp, ShaderManager, UniformProvider, UniformBinding, RenderKit,ExportManager,ShaderHotReload,ShaderControls,RemoteCommand,RemoteControl};
 use winit::event::*;
 use std::path::PathBuf;
 
@@ -33,6 +33,7 @@ struct Shader {
     time_bind_group_layout: wgpu::BindGroupLayout,    
     resolution_bind_group_layout: wgpu::BindGroupLayout,
     params_bind_group_layout: wgpu::BindGroupLayout,
+    remote_control: Option<RemoteControl>,
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -242,6 +243,7 @@ impl ShaderManager for Shader {
             time_bind_group_layout,
             resolution_bind_group_layout,
             params_bind_group_layout,
+            remote_control: RemoteControl::from_env(),
         }
     }
 
@@ -279,6 +281,24 @@ impl ShaderManager for Shader {
         
         let mut params = self.params_uniform.data;
         let mut changed = false;
+        if let Some(remote_control) = &self.remote_control {
+            for command in remote_control.drain() {
+                match command {
+                    RemoteCommand::SetF32 { id, value } => {
+                        changed |= apply_remote_f32(&mut params, &id, value);
+                    }
+                    RemoteCommand::SetColor3 { id, value } => {
+                        if id == "background_color" {
+                            params.background_color = value;
+                            changed = true;
+                        }
+                    }
+                    RemoteCommand::Pulse { .. } |
+                    RemoteCommand::Note { .. } |
+                    RemoteCommand::Transport { .. } => {}
+                }
+            }
+        }
         let mut should_start_export = false;
         let mut export_request = self.base.export_manager.get_ui_request();
         let mut controls_request = self.base.controls.get_ui_request(
@@ -380,4 +400,16 @@ impl ShaderManager for Shader {
         }
         false
     }
+}
+
+fn apply_remote_f32(params: &mut ShaderParams, id: &str, value: f32) -> bool {
+    match id {
+        "square_size" => params.square_size = value.clamp(0.05, 0.5),
+        "circle_radius" => params.circle_radius = value.clamp(0.05, 0.2),
+        "edge_thickness" => params.edge_thickness = value.clamp(0.001, 0.01),
+        "animation_speed" => params.animation_speed = value.clamp(1.0, 30.0),
+        "edge_color_intensity" => params.edge_color_intensity = value.clamp(0.1, 2.0),
+        _ => return false,
+    }
+    true
 }

--- a/src/capi.rs
+++ b/src/capi.rs
@@ -1,0 +1,288 @@
+use std::ffi::{CStr, CString};
+use std::net::UdpSocket;
+use std::os::raw::c_char;
+use std::path::PathBuf;
+use std::process::{Child, Command};
+use std::ptr;
+use std::sync::{Mutex, OnceLock};
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CuneusStatus {
+    Ok = 0,
+    Null = 1,
+    InvalidArgument = 2,
+    NotFound = 3,
+    IoError = 4,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CuneusParamType {
+    F32 = 0,
+    Color3 = 1,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct CuneusParamDesc {
+    pub id: *const c_char,
+    pub label: *const c_char,
+    pub param_type: CuneusParamType,
+    pub min_value: f32,
+    pub max_value: f32,
+    pub default_value: f32,
+    pub flags: u32,
+}
+
+pub struct CuneusInstance {
+    bin_name: &'static str,
+    remote_port: u16,
+    socket: UdpSocket,
+    child: Option<Child>,
+}
+
+struct ParamSpec {
+    id: &'static CStr,
+    label: &'static CStr,
+    param_type: CuneusParamType,
+    min_value: f32,
+    max_value: f32,
+    default_value: f32,
+    flags: u32,
+}
+
+macro_rules! cstr {
+    ($value:literal) => {
+        unsafe { CStr::from_bytes_with_nul_unchecked(concat!($value, "\0").as_bytes()) }
+    };
+}
+
+const ROTO_PARAMS: &[ParamSpec] = &[
+    ParamSpec { id: cstr!("square_size"), label: cstr!("Square Size"), param_type: CuneusParamType::F32, min_value: 0.05, max_value: 0.5, default_value: 0.2, flags: 0 },
+    ParamSpec { id: cstr!("circle_radius"), label: cstr!("Circle Radius"), param_type: CuneusParamType::F32, min_value: 0.05, max_value: 0.2, default_value: 0.11, flags: 0 },
+    ParamSpec { id: cstr!("edge_thickness"), label: cstr!("Edge Thickness"), param_type: CuneusParamType::F32, min_value: 0.001, max_value: 0.01, default_value: 0.003, flags: 0 },
+    ParamSpec { id: cstr!("animation_speed"), label: cstr!("Animation Speed"), param_type: CuneusParamType::F32, min_value: 1.0, max_value: 30.0, default_value: 12.0, flags: 0 },
+    ParamSpec { id: cstr!("background_color"), label: cstr!("Background Color"), param_type: CuneusParamType::Color3, min_value: 0.0, max_value: 1.0, default_value: 0.5, flags: 0 },
+    ParamSpec { id: cstr!("edge_color_intensity"), label: cstr!("Edge Brightness"), param_type: CuneusParamType::F32, min_value: 0.1, max_value: 2.0, default_value: 1.0, flags: 0 },
+];
+
+const BINS: &[&CStr] = &[cstr!("roto")];
+
+static LAST_ERROR: OnceLock<Mutex<CString>> = OnceLock::new();
+
+fn params_for_bin(bin_name: &str) -> Option<&'static [ParamSpec]> {
+    match bin_name {
+        "roto" => Some(ROTO_PARAMS),
+        _ => None,
+    }
+}
+
+fn set_last_error(message: impl Into<String>) {
+    let sanitized = message.into().replace('\0', " ");
+    let error = CString::new(sanitized).unwrap_or_else(|_| CString::new("unknown cuneus error").unwrap());
+    let lock = LAST_ERROR.get_or_init(|| Mutex::new(CString::new("").unwrap()));
+    if let Ok(mut last_error) = lock.lock() {
+        *last_error = error;
+    }
+}
+
+unsafe fn string_from_ptr(ptr: *const c_char) -> Option<String> {
+    if ptr.is_null() {
+        return None;
+    }
+    CStr::from_ptr(ptr).to_str().ok().map(ToOwned::to_owned)
+}
+
+fn send(instance: &CuneusInstance, message: String) -> CuneusStatus {
+    match instance.socket.send_to(message.as_bytes(), ("127.0.0.1", instance.remote_port)) {
+        Ok(_) => CuneusStatus::Ok,
+        Err(error) => {
+            set_last_error(error.to_string());
+            CuneusStatus::IoError
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn cuneus_bin_count() -> usize {
+    BINS.len()
+}
+
+#[no_mangle]
+pub extern "C" fn cuneus_bin_name(index: usize) -> *const c_char {
+    BINS.get(index).map_or(ptr::null(), |name| name.as_ptr())
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cuneus_instance_open(
+    bin_name: *const c_char,
+    executable_dir: *const c_char,
+    remote_port: u16,
+) -> *mut CuneusInstance {
+    let Some(bin_name_string) = string_from_ptr(bin_name) else {
+        set_last_error("bin_name is null or invalid utf-8");
+        return ptr::null_mut();
+    };
+    let Some(params) = params_for_bin(&bin_name_string) else {
+        set_last_error(format!("unknown cuneus bin: {bin_name_string}"));
+        return ptr::null_mut();
+    };
+    if params.is_empty() {
+        set_last_error(format!("no parameters registered for {bin_name_string}"));
+        return ptr::null_mut();
+    }
+
+    let socket = match UdpSocket::bind(("127.0.0.1", 0)) {
+        Ok(socket) => socket,
+        Err(error) => {
+            set_last_error(error.to_string());
+            return ptr::null_mut();
+        }
+    };
+
+    let mut child = None;
+    if let Some(dir) = string_from_ptr(executable_dir).filter(|value| !value.is_empty()) {
+        let mut executable = PathBuf::from(dir);
+        executable.push(&bin_name_string);
+        if cfg!(windows) {
+            executable.set_extension("exe");
+        }
+        match Command::new(&executable)
+            .env("CUNEUS_REMOTE_PORT", remote_port.to_string())
+            .spawn()
+        {
+            Ok(process) => child = Some(process),
+            Err(error) => {
+                set_last_error(format!("failed to launch {}: {error}", executable.display()));
+                return ptr::null_mut();
+            }
+        }
+    }
+
+    let bin_name_static = match bin_name_string.as_str() {
+        "roto" => "roto",
+        _ => unreachable!(),
+    };
+
+    Box::into_raw(Box::new(CuneusInstance {
+        bin_name: bin_name_static,
+        remote_port,
+        socket,
+        child,
+    }))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cuneus_instance_free(instance: *mut CuneusInstance) {
+    if instance.is_null() {
+        return;
+    }
+    let mut instance = Box::from_raw(instance);
+    if let Some(mut child) = instance.child.take() {
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn cuneus_last_error() -> *const c_char {
+    let lock = LAST_ERROR.get_or_init(|| Mutex::new(CString::new("").unwrap()));
+    lock.lock().map_or(ptr::null(), |value| value.as_ptr())
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cuneus_param_count(instance: *mut CuneusInstance) -> usize {
+    let Some(instance) = instance.as_ref() else {
+        return 0;
+    };
+    params_for_bin(instance.bin_name).map_or(0, |params| params.len())
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cuneus_param_desc(
+    instance: *mut CuneusInstance,
+    index: usize,
+    out_desc: *mut CuneusParamDesc,
+) -> CuneusStatus {
+    let Some(instance) = instance.as_ref() else {
+        return CuneusStatus::Null;
+    };
+    let Some(out_desc) = out_desc.as_mut() else {
+        return CuneusStatus::Null;
+    };
+    let Some(param) = params_for_bin(instance.bin_name).and_then(|params| params.get(index)) else {
+        return CuneusStatus::NotFound;
+    };
+    *out_desc = CuneusParamDesc {
+        id: param.id.as_ptr(),
+        label: param.label.as_ptr(),
+        param_type: param.param_type,
+        min_value: param.min_value,
+        max_value: param.max_value,
+        default_value: param.default_value,
+        flags: param.flags,
+    };
+    CuneusStatus::Ok
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cuneus_set_param_f32(
+    instance: *mut CuneusInstance,
+    id: *const c_char,
+    value: f32,
+) -> CuneusStatus {
+    let Some(instance) = instance.as_ref() else {
+        return CuneusStatus::Null;
+    };
+    let Some(id) = string_from_ptr(id) else {
+        return CuneusStatus::InvalidArgument;
+    };
+    send(instance, format!("set_f32 {id} {value}"))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cuneus_set_param_color3(
+    instance: *mut CuneusInstance,
+    id: *const c_char,
+    r: f32,
+    g: f32,
+    b: f32,
+) -> CuneusStatus {
+    let Some(instance) = instance.as_ref() else {
+        return CuneusStatus::Null;
+    };
+    let Some(id) = string_from_ptr(id) else {
+        return CuneusStatus::InvalidArgument;
+    };
+    send(instance, format!("set_color3 {id} {r} {g} {b}"))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cuneus_pulse(instance: *mut CuneusInstance, velocity: f32) -> CuneusStatus {
+    let Some(instance) = instance.as_ref() else {
+        return CuneusStatus::Null;
+    };
+    send(instance, format!("pulse {velocity}"))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cuneus_note(instance: *mut CuneusInstance, pitch: f32, velocity: f32) -> CuneusStatus {
+    let Some(instance) = instance.as_ref() else {
+        return CuneusStatus::Null;
+    };
+    send(instance, format!("note {pitch} {velocity}"))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cuneus_set_transport(
+    instance: *mut CuneusInstance,
+    bpm: f32,
+    beat: f32,
+    measure: f32,
+) -> CuneusStatus {
+    let Some(instance) = instance.as_ref() else {
+        return CuneusStatus::Null;
+    };
+    send(instance, format!("transport {bpm} {beat} {measure}"))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,8 @@ mod export;
 mod hot;
 mod controls;
 mod atomic;
+mod capi;
+mod remote;
 #[cfg(feature = "media")]
 pub mod gst;
 pub mod compute;
@@ -45,6 +47,7 @@ pub use export::{ExportSettings, ExportManager, ExportError, ExportUiState, save
 pub use hot::ShaderHotReload;
 pub use controls::{ControlsRequest, ShaderControls};
 pub use atomic::AtomicBuffer;
+pub use remote::{RemoteCommand, RemoteControl};
 pub use mouse::*;
 pub use hdri::*;
 pub use font::{FontSystem, FontUniforms, CharInfo};
@@ -101,7 +104,7 @@ impl Core {
     pub async fn new(window: Window) -> Self {
         let size = window.inner_size();
         let instance_desc = wgpu::InstanceDescriptor {
-            backends: wgpu::Backends::all(),
+            backends: wgpu::Backends::DX12,
             backend_options: wgpu::BackendOptions::default(),
             ..Default::default()
         };

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -1,0 +1,94 @@
+use std::collections::VecDeque;
+use std::net::UdpSocket;
+use std::sync::{Arc, Mutex};
+use std::thread;
+
+#[derive(Clone, Debug)]
+pub enum RemoteCommand {
+    SetF32 { id: String, value: f32 },
+    SetColor3 { id: String, value: [f32; 3] },
+    Pulse { velocity: f32 },
+    Note { pitch: f32, velocity: f32 },
+    Transport { bpm: f32, beat: f32, measure: f32 },
+}
+
+#[derive(Clone, Default)]
+pub struct RemoteControl {
+    commands: Arc<Mutex<VecDeque<RemoteCommand>>>,
+}
+
+impl RemoteControl {
+    pub fn from_env() -> Option<Self> {
+        let port = std::env::var("CUNEUS_REMOTE_PORT")
+            .ok()
+            .and_then(|value| value.parse::<u16>().ok())?;
+        Self::listen(port).ok()
+    }
+
+    pub fn listen(port: u16) -> std::io::Result<Self> {
+        let socket = UdpSocket::bind(("127.0.0.1", port))?;
+        socket.set_nonblocking(false)?;
+
+        let remote = Self::default();
+        let commands = remote.commands.clone();
+
+        thread::Builder::new()
+            .name(format!("cuneus-remote-{port}"))
+            .spawn(move || {
+                let mut buffer = [0_u8; 1024];
+                loop {
+                    let Ok((len, _addr)) = socket.recv_from(&mut buffer) else {
+                        continue;
+                    };
+                    let Ok(text) = std::str::from_utf8(&buffer[..len]) else {
+                        continue;
+                    };
+                    if let Some(command) = parse_command(text.trim()) {
+                        if let Ok(mut queue) = commands.lock() {
+                            queue.push_back(command);
+                        }
+                    }
+                }
+            })?;
+
+        Ok(remote)
+    }
+
+    pub fn drain(&self) -> Vec<RemoteCommand> {
+        let Ok(mut queue) = self.commands.lock() else {
+            return Vec::new();
+        };
+        queue.drain(..).collect()
+    }
+}
+
+fn parse_command(text: &str) -> Option<RemoteCommand> {
+    let mut parts = text.split_whitespace();
+    match parts.next()? {
+        "set_f32" => Some(RemoteCommand::SetF32 {
+            id: parts.next()?.to_string(),
+            value: parts.next()?.parse().ok()?,
+        }),
+        "set_color3" => Some(RemoteCommand::SetColor3 {
+            id: parts.next()?.to_string(),
+            value: [
+                parts.next()?.parse().ok()?,
+                parts.next()?.parse().ok()?,
+                parts.next()?.parse().ok()?,
+            ],
+        }),
+        "pulse" => Some(RemoteCommand::Pulse {
+            velocity: parts.next()?.parse().ok()?,
+        }),
+        "note" => Some(RemoteCommand::Note {
+            pitch: parts.next()?.parse().ok()?,
+            velocity: parts.next()?.parse().ok()?,
+        }),
+        "transport" => Some(RemoteCommand::Transport {
+            bpm: parts.next()?.parse().ok()?,
+            beat: parts.next()?.parse().ok()?,
+            measure: parts.next()?.parse().ok()?,
+        }),
+        _ => None,
+    }
+}


### PR DESCRIPTION
hello!

https://github.com/davehorner/BespokeSynth/tree/cuneus_bespokesynth

using this branch and the above, I am able to remote control the roto bin via BespokeSynth.

I have a want to automate the display of the ui overlay too (hidden/show).  I often run all the examples in batch.  I would like to see them in their full glory and also programatically make them more interesting.

Recently had success with Bespoke and StableAudio3, that was done using a cbindgen api.  That work is in the fork, fyi.

basically, c api for cuneus + custum udp remote control capabilities.  Would love to see this work for all the examples if you find it interesting. 

## Summary
- Adds a `cdylib` C API surface for controlling Cuneus from external hosts.
- Adds exported parameter descriptors and command helpers for the initial `roto` integration.
- Adds lightweight UDP remote control used by sidecar-launched bins.
- Wires `roto` to accept remote parameter updates.

## New Environment Variable
- `CUNEUS_REMOTE_PORT`: when set, a bin listens on `127.0.0.1:<port>` for remote-control commands.

Example:

```powershell
$env:CUNEUS_REMOTE_PORT = "7841"
cargo run --bin roto --no-default-features
Remote Commands
The current receiver accepts whitespace-delimited UDP messages:

set_f32 square_size 0.25
set_f32 animation_speed 18.0
set_color3 background_color 0.1 0.2 0.3
pulse 1.0
note 60 0.8
transport 120 1 0
```

Notes
roto is the first bin wired into the parameter registry.
The C API is designed around stable parameter IDs rather than UI slider labels.
Host calls enqueue/send commands to the render-side listener instead of directly mutating WGPU state.

What we added is a small UDP text protocol:

set_f32 square_size 0.25
set_color3 background_color 0.1 0.2 0.3
pulse 1.0
note 60 0.8
transport 120 1 0
It listens only when:

CUNEUS_REMOTE_PORT=7841
is set.

So Bespoke is not using its oscoutput module for this bridge yet. The Bespoke cuneus module calls the C API, and the C API sends those UDP text commands to the launched Cuneus sidecar.

For the PR, I’d call it “UDP remote control” or “sidecar command protocol,” not OSC.  But future improvement would be to extend this to OSC so as to be useful from things like orca and other OSC control applications.

Happy to discuss!
--dave