### PR TITLE
fix(shader): inline getpent function to bypass Naga HLSL bug

### DIFF
--- a/shaders/cuneus.wgsl
+++ b/shaders/cuneus.wgsl
@@ -152,41 +152,34 @@ fn cuneus(p: vec2<f32>, off: f32) -> f32 {
     return d;
 }
 
-// Get letter position keypoints for lighting
-fn texlight(uv: vec2<f32>, scale: f32, time: f32) -> array<vec2<f32>, 8> {
-    var positions: array<vec2<f32>, 8>;
-    let baseOffset = 3.0 + 3.0 * scale;
+fn getLightIntensity(uv: vec2<f32>, textDist: f32, layer: f32, time: f32) -> f32 {
+    var lightPositions: array<vec2<f32>, 8>;
+    let baseOffset = 3.0 + 3.0 * layer;
     
     // C
-    positions[0] = vec2<f32>(-baseOffset + 0.5, 0.5);
+    lightPositions[0] = vec2<f32>(-baseOffset + 0.5, 0.5);
     
     // U
-    positions[1] = vec2<f32>(-baseOffset + 1.55, 0.5);
+    lightPositions[1] = vec2<f32>(-baseOffset + 1.55, 0.5);
     
     // N
-    positions[2] = vec2<f32>(-baseOffset + 2.65, 0.5);
+    lightPositions[2] = vec2<f32>(-baseOffset + 2.65, 0.5);
     
     // E
-    positions[3] = vec2<f32>(-baseOffset + 3.65, 0.5);
+    lightPositions[3] = vec2<f32>(-baseOffset + 3.65, 0.5);
     
     // U
-    positions[4] = vec2<f32>(-baseOffset + 4.65, 0.5);
+    lightPositions[4] = vec2<f32>(-baseOffset + 4.65, 0.5);
     
     // S
-    positions[5] = vec2<f32>(-baseOffset + 5.525, 0.5);
+    lightPositions[5] = vec2<f32>(-baseOffset + 5.525, 0.5);
     
     // Additional dynamic points
-    positions[6] = vec2<f32>(-baseOffset + oscillate(0.0, 6.0, 8.0, time), 
+    lightPositions[6] = vec2<f32>(-baseOffset + oscillate(0.0, 6.0, 8.0, time), 
                     oscillate(0.0, 1.0, 5.0, time));
     
-    positions[7] = vec2<f32>(-baseOffset + oscillate(6.0, 0.0, 7.0, time), 
+    lightPositions[7] = vec2<f32>(-baseOffset + oscillate(6.0, 0.0, 7.0, time), 
                     oscillate(1.0, 0.0, 6.0, time));
-    
-    return positions;
-}
-
-fn getLightIntensity(uv: vec2<f32>, textDist: f32, layer: f32, time: f32) -> f32 {
-    let lightPositions = texlight(uv, layer, time);
     
     let phaseShift1 = sin(layer * 13.37 + time * 0.3);
     let phaseShift2 = cos(layer * 7.54 - time * 0.4);

--- a/shaders/sdvert.wgsl
+++ b/shaders/sdvert.wgsl
@@ -83,9 +83,10 @@ fn sdPentagon(p: vec2<f32>, r: f32, angle: f32) -> f32 {
     return max(d, 0.1);
 }
 
-fn getpent(uv: vec2<f32>, size: f32, angle: f32) -> array<vec2<f32>, 5> {
+//get light
+fn gl(uv: vec2<f32>, pentagon: f32, layer: f32, time: f32, angle: f32) -> f32 {
     var vertices: array<vec2<f32>, 5>;
-    let r = size * 0.8;
+    let r = layer * 0.8;
 
     for(var i: i32 = 0; i < 5; i = i + 1) {
         let a = (f32(i) / 5.0) * 2.0 * PI;
@@ -96,12 +97,6 @@ fn getpent(uv: vec2<f32>, size: f32, angle: f32) -> array<vec2<f32>, 5> {
     for(var i: i32 = 0; i < 5; i = i + 1) {
         vertices[i] = rot * vertices[i] + uv;
     }
-
-    return vertices;
-}
-//get light
-fn gl(uv: vec2<f32>, pentagon: f32, layer: f32, time: f32, angle: f32) -> f32 {
-    let vertices = getpent(uv, layer, angle);
 
     let phaseShift1 = sin(layer * 13.37 + time * 0.3);
     let phaseShift2 = cos(layer * 7.54 - time * 0.4);


### PR DESCRIPTION
This inlines the getpent function to avoid returning a ec2 array from a function. Naga's HLSL backend currently has a bug where it generates invalid D3D array conversions when functions return arrays directly.


cuneus example, and it turns out it was crashing with the exact same Naga HLSL shader bug! The texlight function in cuneus.wgsl was returning an array of size 8, which the WGPU DirectX backend also fails to compile.

I've gone ahead and fixed shaders/cuneus.wgsl exactly the same way as the first one (by inlining texlight into getLightIntensity). I then ran cargo run --bin cuneus and it booted right up and created the pipeline successfully!