### PR TITLE
Expose raw pcm samples from mic and media file audio sources

### DIFF
--- a/src/gst/video.rs
+++ b/src/gst/video.rs
@@ -5,10 +5,85 @@ use gstreamer as gst;
 use gstreamer_app as gst_app;
 use gstreamer_video as gst_video;
 use log::{debug, error, info, warn};
+use std::collections::VecDeque;
 use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 use wgpu;
+
+/// Cap raw PCM buffer at ~10 seconds so memory stays bounded when the
+/// consumer is slow or absent. Oldest samples drop first.
+const PCM_BUFFER_CAP: usize = 44100 * 10;
+
+/// Raw PCM tap output rate — mono `f32` samples. Consumers that need a
+/// different rate should resample on their side.
+const PCM_SAMPLE_RATE: u32 = 44100;
+
+/// Elements that make up the parallel raw PCM tap branch. Built optimistically
+/// when audio first arrives; if construction fails the analyzer chain still
+/// runs but the tap is reported absent via `has_pcm`.
+struct PcmTapBranch {
+    tee: gst::Element,
+    queue_main: gst::Element,
+    queue_pcm: gst::Element,
+    audioconvert2: gst::Element,
+    audioresample2: gst::Element,
+    caps_filter: gst::Element,
+    appsink: gst_app::AppSink,
+}
+
+/// Try to construct the PCM tap elements. Returns `None` if any element
+/// fails to build — caller falls back to the plain analyzer chain.
+fn build_pcm_branch() -> Option<PcmTapBranch> {
+    let tee = gst::ElementFactory::make("tee").name("video_audio_tee").build().ok()?;
+    let queue_main = gst::ElementFactory::make("queue").name("video_q_main").build().ok()?;
+    let queue_pcm = gst::ElementFactory::make("queue").name("video_q_pcm").build().ok()?;
+    let audioconvert2 = gst::ElementFactory::make("audioconvert")
+        .name("video_pcm_convert")
+        .build()
+        .ok()?;
+    let audioresample2 = gst::ElementFactory::make("audioresample")
+        .name("video_pcm_resample")
+        .build()
+        .ok()?;
+    let caps_filter = gst::ElementFactory::make("capsfilter")
+        .name("video_pcm_caps")
+        .build()
+        .ok()?;
+    caps_filter.set_property(
+        "caps",
+        &gst::Caps::builder("audio/x-raw")
+            .field("format", "F32LE")
+            .field("rate", PCM_SAMPLE_RATE as i32)
+            .field("channels", 1i32)
+            .build(),
+    );
+    let raw_sink = gst::ElementFactory::make("appsink")
+        .name("video_pcm_sink")
+        .build()
+        .ok()?;
+    let appsink = raw_sink.dynamic_cast::<gst_app::AppSink>().ok()?;
+    appsink.set_caps(Some(
+        &gst::Caps::builder("audio/x-raw")
+            .field("format", "F32LE")
+            .field("rate", PCM_SAMPLE_RATE as i32)
+            .field("channels", 1i32)
+            .build(),
+    ));
+    appsink.set_max_buffers(8);
+    appsink.set_drop(true);
+    appsink.set_sync(false);
+    Some(PcmTapBranch {
+        tee,
+        queue_main,
+        queue_pcm,
+        audioconvert2,
+        audioresample2,
+        caps_filter,
+        appsink,
+    })
+}
 
 #[derive(Debug, Clone, Default)]
 pub struct SpectrumData {
@@ -85,6 +160,13 @@ pub struct VideoTextureManager {
     bpm_value: Arc<Mutex<f32>>,
     /// Whether video track was found
     has_video: Arc<Mutex<bool>>,
+    /// Whether the parallel raw PCM appsink branch attached successfully.
+    /// Set inside the lazy audio-pipeline builder when the tap wires up.
+    has_pcm: Arc<AtomicBool>,
+    /// Bounded ring buffer of raw `f32` mono PCM samples at
+    /// `PCM_SAMPLE_RATE`. Drained with `pop_pcm_samples` — oldest samples
+    /// drop when the buffer fills.
+    pcm_samples: Arc<Mutex<VecDeque<f32>>>,
 }
 
 impl VideoTextureManager {
@@ -192,6 +274,13 @@ impl VideoTextureManager {
         let spectrum_data = Arc::new(Mutex::new(SpectrumData::default()));
         let audio_level = Arc::new(Mutex::new(AudioLevel::default()));
 
+        // Raw PCM tap state — captured into the pad-added closure so the
+        // appsink callback can write into it. `has_pcm` flips to true if
+        // the tap successfully attaches when the audio pad arrives.
+        let has_pcm = Arc::new(AtomicBool::new(false));
+        let has_pcm_for_closure = has_pcm.clone();
+        let pcm_samples = Arc::new(Mutex::new(VecDeque::with_capacity(PCM_BUFFER_CAP)));
+        let pcm_samples_for_closure = pcm_samples.clone();
 
         decodebin.connect_pad_added(move |_, pad| {
             let caps = match pad.current_caps() {
@@ -332,29 +421,24 @@ impl VideoTextureManager {
                             }
                         };
 
-                        // Add elements to pipeline
-                        if let Err(e) = pad
+                        // Optional raw PCM tap. The tap lives on a parallel
+                        // branch of a tee after audioresample so the analyzer
+                        // chain and playback stay unchanged. If any of the
+                        // tap elements fail to build, we silently skip the
+                        // tap (audio playback / analysis still works) — only
+                        // the consumer-facing `has_pcm()` reports false.
+                        let pcm_branch = build_pcm_branch();
+
+                        let parent_pipeline = pad
                             .parent_element()
                             .unwrap()
                             .parent()
                             .unwrap()
                             .downcast_ref::<gst::Pipeline>()
                             .unwrap()
-                            .add_many([
-                                &audioconvert,
-                                &audioresample,
-                                &level,
-                                &bpmdetect,
-                                &spectrum,
-                                &volume,
-                                &audio_sink,
-                            ])
-                        {
-                            warn!("Failed to add audio elements: {e:?}");
-                            return;
-                        }
-                        // Link audio elements
-                        if let Err(e) = gst::Element::link_many([
+                            .clone();
+
+                        let analyzer_chain: &[&gst::Element] = &[
                             &audioconvert,
                             &audioresample,
                             &level,
@@ -362,9 +446,125 @@ impl VideoTextureManager {
                             &spectrum,
                             &volume,
                             &audio_sink,
-                        ]) {
-                            warn!("Failed to link audio elements: {e:?}");
+                        ];
+                        if let Err(e) = parent_pipeline.add_many(analyzer_chain) {
+                            warn!("Failed to add audio elements: {e:?}");
                             return;
+                        }
+
+                        let mut pcm_attached = false;
+                        if let Some(branch) = &pcm_branch {
+                            // Wire the appsink callback to the shared ring buffer.
+                            let pcm_buffer = pcm_samples_for_closure.clone();
+                            branch.appsink.set_callbacks(
+                                gst_app::AppSinkCallbacks::builder()
+                                    .new_sample(move |sink| {
+                                        let sample = sink
+                                            .pull_sample()
+                                            .map_err(|_| gst::FlowError::Eos)?;
+                                        let buffer = sample
+                                            .buffer()
+                                            .ok_or(gst::FlowError::Error)?;
+                                        let map = buffer
+                                            .map_readable()
+                                            .map_err(|_| gst::FlowError::Error)?;
+                                        let bytes = map.as_slice();
+                                        let samples: &[f32] =
+                                            bytemuck::cast_slice(bytes);
+                                        if let Ok(mut q) = pcm_buffer.lock() {
+                                            for &s in samples {
+                                                if q.len() >= PCM_BUFFER_CAP {
+                                                    q.pop_front();
+                                                }
+                                                q.push_back(s);
+                                            }
+                                        }
+                                        Ok(gst::FlowSuccess::Ok)
+                                    })
+                                    .build(),
+                            );
+
+                            // Add tap elements to the pipeline. Failure here
+                            // shouldn't kill the analyzer chain — drop the
+                            // tap and continue with the plain linear link.
+                            let add_ok = parent_pipeline
+                                .add_many([
+                                    &branch.tee,
+                                    &branch.queue_main,
+                                    &branch.queue_pcm,
+                                    &branch.audioconvert2,
+                                    &branch.audioresample2,
+                                    &branch.caps_filter,
+                                    branch.appsink.upcast_ref::<gst::Element>(),
+                                ])
+                                .is_ok();
+                            if add_ok {
+                                // Link audioconvert → audioresample → tee →
+                                //   queue_main → level → bpmdetect → spectrum → volume → audio_sink
+                                //   queue_pcm  → audioconvert2 → audioresample2 → caps → appsink
+                                let upstream_ok = gst::Element::link_many([
+                                    &audioconvert,
+                                    &audioresample,
+                                    &branch.tee,
+                                ])
+                                .is_ok();
+                                let main_ok = gst::Element::link_many([
+                                    &branch.tee,
+                                    &branch.queue_main,
+                                    &level,
+                                    &bpmdetect,
+                                    &spectrum,
+                                    &volume,
+                                    &audio_sink,
+                                ])
+                                .is_ok();
+                                let pcm_ok = gst::Element::link_many([
+                                    &branch.tee,
+                                    &branch.queue_pcm,
+                                    &branch.audioconvert2,
+                                    &branch.audioresample2,
+                                    &branch.caps_filter,
+                                    branch.appsink.upcast_ref::<gst::Element>(),
+                                ])
+                                .is_ok();
+
+                                if upstream_ok && main_ok && pcm_ok {
+                                    let _ = branch.tee.sync_state_with_parent();
+                                    let _ = branch.queue_main.sync_state_with_parent();
+                                    let _ = branch.queue_pcm.sync_state_with_parent();
+                                    let _ = branch.audioconvert2.sync_state_with_parent();
+                                    let _ = branch.audioresample2.sync_state_with_parent();
+                                    let _ = branch.caps_filter.sync_state_with_parent();
+                                    let _ = branch.appsink.sync_state_with_parent();
+                                    pcm_attached = true;
+                                } else {
+                                    warn!(
+                                        "Video: PCM tap link failed (up={upstream_ok} \
+                                         main={main_ok} pcm={pcm_ok}); falling back"
+                                    );
+                                }
+                            } else {
+                                warn!("Video: PCM tap add_many failed; falling back");
+                            }
+                        }
+
+                        if !pcm_attached {
+                            // Fallback path: original linear chain, no PCM tap.
+                            if let Err(e) = gst::Element::link_many([
+                                &audioconvert,
+                                &audioresample,
+                                &level,
+                                &bpmdetect,
+                                &spectrum,
+                                &volume,
+                                &audio_sink,
+                            ]) {
+                                warn!("Failed to link audio elements: {e:?}");
+                                return;
+                            }
+                        } else {
+                            has_pcm_for_closure.store(true, Ordering::Relaxed);
+                            info!("Video: raw PCM tap attached ({PCM_SAMPLE_RATE} Hz mono f32)");
                         }
 
                         // Set elements to PAUSED state
@@ -501,6 +701,8 @@ impl VideoTextureManager {
             audio_level,
             bpm_value: Arc::new(Mutex::new(0.0)),
             has_video: has_video.clone(),
+            has_pcm,
+            pcm_samples,
         };
         // Start pipeline in paused state to get video info
         if video_texture
@@ -1115,6 +1317,37 @@ impl VideoTextureManager {
             Err(_) => AudioLevel::default(),
         }
     }
+
+    /// Whether the raw PCM tap is delivering samples. False if the media
+    /// has no audio track or the appsink branch failed to attach — spectrum
+    /// and level may still be working in either case.
+    pub fn has_pcm(&self) -> bool {
+        self.has_pcm.load(Ordering::Relaxed)
+    }
+
+    /// Source sample rate of the raw PCM samples (44.1kHz). Consumers that
+    /// need a different rate should resample on their side.
+    pub fn pcm_sample_rate(&self) -> u32 {
+        PCM_SAMPLE_RATE
+    }
+
+    /// Number of raw PCM samples currently buffered. Useful when you need
+    /// to wait for a full chunk before processing.
+    pub fn pcm_available(&self) -> usize {
+        self.pcm_samples.lock().map(|q| q.len()).unwrap_or(0)
+    }
+
+    /// Drain up to `count` raw PCM samples in FIFO order. Returns fewer
+    /// than `count` (possibly zero) when the buffer is short. Samples are
+    /// mono `f32` in `[-1.0, 1.0]` at `pcm_sample_rate()`.
+    pub fn pop_pcm_samples(&mut self, count: usize) -> Vec<f32> {
+        let Ok(mut q) = self.pcm_samples.lock() else {
+            return Vec::new();
+        };
+        let n = count.min(q.len());
+        q.drain(..n).collect()
+    }
+
     pub fn get_bpm(&self) -> f32 {
         if !self.has_audio {
             return 0.0;

--- a/src/gst/webcam.rs
+++ b/src/gst/webcam.rs
@@ -6,9 +6,19 @@ use gstreamer as gst;
 use gstreamer_app as gst_app;
 use gstreamer_video as gst_video;
 use log::{debug, info, warn};
+use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 use wgpu;
+
+/// Cap raw PCM buffer at ~10 seconds of 44.1kHz mono so memory stays bounded
+/// if the consumer is slow or absent. Oldest samples drop first.
+const PCM_BUFFER_CAP: usize = 44100 * 10;
+
+/// Pipeline sample rate for the raw PCM tap. Consumers that need a different
+/// rate should resample on their side — the engine ships raw samples at the
+/// source rate without making assumptions about the destination format.
+const PCM_SAMPLE_RATE: u32 = 44100;
 
 /// Manages a webcam texture that can be updated frame by frame. My approach is actually same for src/gst/video.rs
 pub struct WebcamTextureManager {
@@ -39,6 +49,12 @@ pub struct WebcamTextureManager {
     spectrum_data: Arc<Mutex<SpectrumData>>,
     /// Audio level (RMS/peak) from the mic input.
     audio_level: Arc<Mutex<AudioLevel>>,
+    /// Whether the parallel raw PCM appsink branch attached successfully.
+    has_pcm: bool,
+    /// Bounded ring buffer of raw f32 PCM samples from the mic at
+    /// `PCM_SAMPLE_RATE`. Drain with `pop_pcm_samples` — oldest samples drop
+    /// when the buffer fills (see `PCM_BUFFER_CAP`).
+    pcm_samples: Arc<Mutex<VecDeque<f32>>>,
 }
 
 impl WebcamTextureManager {
@@ -151,11 +167,14 @@ impl WebcamTextureManager {
         ])
         .map_err(|_| anyhow!("Failed to link webcam elements"))?;
 
-        // Audio branch: microphone → audioconvert → audioresample → 44.1kHz caps
-        // → spectrum (FFT) → level (RMS/peak) → fakesink. Posts spectrum and
-        // level messages on the bus identical to gst/video.rs so RenderKit's
-        // audio spectrum path treats webcam mic and video audio uniformly.
-        let has_audio = Self::try_attach_audio_branch(&pipeline);
+        // Audio branch: microphone → audioconvert → audioresample → 44.1kHz
+        // F32LE caps → tee → [spectrum/level → fakesink, raw PCM → appsink].
+        // The spectrum branch posts FFT magnitude/level messages on the bus
+        // for the shader-side audio path. The PCM branch fills a bounded
+        // ring buffer so consumers have the raw time-domain waveform
+        // available alongside the FFT.
+        let pcm_samples = Arc::new(Mutex::new(VecDeque::with_capacity(PCM_BUFFER_CAP)));
+        let (has_audio, has_pcm) = Self::try_attach_audio_branch(&pipeline, pcm_samples.clone());
 
         // Create shared state
         let current_frame = Arc::new(Mutex::new(None));
@@ -239,6 +258,8 @@ impl WebcamTextureManager {
             has_audio,
             spectrum_data: Arc::new(Mutex::new(SpectrumData::default())),
             audio_level: Arc::new(Mutex::new(AudioLevel::default())),
+            has_pcm,
+            pcm_samples,
         };
 
         info!("Webcam texture manager created successfully");
@@ -385,11 +406,50 @@ impl WebcamTextureManager {
         0.0
     }
 
-    /// mic → spectrum + level → fakesink
-    /// if fail:
-    /// (no mic, missing element, permission denied) leave video working
-    /// and just skip audio rather than aborting can aboty
-    fn try_attach_audio_branch(pipeline: &gst::Pipeline) -> bool {
+    /// Whether the raw PCM tap is delivering samples. False if the appsink
+    /// branch failed to attach (missing GStreamer plugin, format negotiation
+    /// failure, etc.) — spectrum/level may still be working in that case.
+    pub fn has_pcm(&self) -> bool {
+        self.has_pcm
+    }
+
+    /// Source sample rate of the raw PCM samples (44.1kHz at present).
+    /// Consumers requiring a different rate should resample on their side.
+    pub fn pcm_sample_rate(&self) -> u32 {
+        PCM_SAMPLE_RATE
+    }
+
+    /// Number of raw PCM samples currently buffered. Useful when you need
+    /// to wait for a full chunk before processing.
+    pub fn pcm_available(&self) -> usize {
+        self.pcm_samples.lock().map(|q| q.len()).unwrap_or(0)
+    }
+
+    /// Drain up to `count` raw PCM samples from the ring buffer in FIFO
+    /// order. Returns fewer than `count` (possibly zero) when the buffer
+    /// is short. The samples are mono `f32` in `[-1.0, 1.0]` at the rate
+    /// reported by `pcm_sample_rate`.
+    pub fn pop_pcm_samples(&mut self, count: usize) -> Vec<f32> {
+        let Ok(mut q) = self.pcm_samples.lock() else {
+            return Vec::new();
+        };
+        let n = count.min(q.len());
+        q.drain(..n).collect()
+    }
+
+    /// Build the audio branch:
+    ///   mic → audioconvert → audioresample → F32LE/44.1kHz/mono caps → tee
+    ///     ├── queue → spectrum (FFT) → level (RMS/peak) → fakesink
+    ///     └── queue → appsink (raw PCM into `pcm_samples`)
+    ///
+    /// Returns `(has_audio, has_pcm)`. If the mic itself can't open, both are
+    /// false and the webcam stays video-only. If the spectrum chain works but
+    /// the PCM tap fails, `has_audio=true, has_pcm=false` — degrading
+    /// gracefully rather than aborting.
+    fn try_attach_audio_branch(
+        pipeline: &gst::Pipeline,
+        pcm_samples: Arc<Mutex<VecDeque<f32>>>,
+    ) -> (bool, bool) {
         // Platform-specific microphone source.
         #[cfg(target_os = "linux")]
         let mic_factory = "pulsesrc";
@@ -402,7 +462,7 @@ impl WebcamTextureManager {
             Ok(e) => e,
             Err(_) => {
                 warn!("Webcam: no microphone source available ({mic_factory}); audio disabled");
-                return false;
+                return (false, false);
             }
         };
 
@@ -410,29 +470,49 @@ impl WebcamTextureManager {
             Ok(e) => e,
             Err(_) => {
                 warn!("Webcam: failed to create audioconvert; audio disabled");
-                return false;
+                return (false, false);
             }
         };
         let audioresample = match gst::ElementFactory::make("audioresample").build() {
             Ok(e) => e,
             Err(_) => {
                 warn!("Webcam: failed to create audioresample; audio disabled");
-                return false;
+                return (false, false);
             }
         };
         let audio_caps_filter = match gst::ElementFactory::make("capsfilter").build() {
             Ok(e) => e,
             Err(_) => {
                 warn!("Webcam: failed to create audio capsfilter; audio disabled");
-                return false;
+                return (false, false);
             }
         };
+        // F32LE upstream so the spectrum/level branch and the PCM appsink can
+        // share one conversion. spectrum accepts F32LE; the appsink reads it
+        // directly as `&[f32]`.
         let audio_caps = gst::Caps::builder("audio/x-raw")
-            .field("rate", 44100i32)
+            .field("format", "F32LE")
+            .field("rate", PCM_SAMPLE_RATE as i32)
             .field("channels", 1i32)
             .build();
         audio_caps_filter.set_property("caps", &audio_caps);
 
+        let tee = match gst::ElementFactory::make("tee").name("webcam_audio_tee").build() {
+            Ok(e) => e,
+            Err(_) => {
+                warn!("Webcam: failed to create tee; audio disabled");
+                return (false, false);
+            }
+        };
+
+        // Spectrum/level branch.
+        let queue_spec = match gst::ElementFactory::make("queue").name("webcam_q_spec").build() {
+            Ok(e) => e,
+            Err(_) => {
+                warn!("Webcam: failed to create spectrum queue; audio disabled");
+                return (false, false);
+            }
+        };
         let spectrum = match gst::ElementFactory::make("spectrum")
             .name("webcam_spectrum")
             .property("bands", 128u32)
@@ -446,10 +526,9 @@ impl WebcamTextureManager {
             Ok(e) => e,
             Err(_) => {
                 warn!("Webcam: failed to create spectrum element; audio disabled");
-                return false;
+                return (false, false);
             }
         };
-
         let level = match gst::ElementFactory::make("level")
             .name("webcam_level")
             .property("interval", 50000000u64)
@@ -460,10 +539,9 @@ impl WebcamTextureManager {
             Ok(e) => e,
             Err(_) => {
                 warn!("Webcam: failed to create level element; audio disabled");
-                return false;
+                return (false, false);
             }
         };
-
         let audio_sink = match gst::ElementFactory::make("fakesink")
             .name("webcam_audio_sink")
             .property("sync", false)
@@ -473,7 +551,7 @@ impl WebcamTextureManager {
             Ok(e) => e,
             Err(_) => {
                 warn!("Webcam: failed to create fakesink; audio disabled");
-                return false;
+                return (false, false);
             }
         };
 
@@ -483,6 +561,8 @@ impl WebcamTextureManager {
                 &audioconvert,
                 &audioresample,
                 &audio_caps_filter,
+                &tee,
+                &queue_spec,
                 &spectrum,
                 &level,
                 &audio_sink,
@@ -490,7 +570,7 @@ impl WebcamTextureManager {
             .is_err()
         {
             warn!("Webcam: failed to add audio elements to pipeline; audio disabled");
-            return false;
+            return (false, false);
         }
 
         if gst::Element::link_many([
@@ -498,18 +578,98 @@ impl WebcamTextureManager {
             &audioconvert,
             &audioresample,
             &audio_caps_filter,
-            &spectrum,
-            &level,
-            &audio_sink,
+            &tee,
         ])
         .is_err()
         {
-            warn!("Webcam: failed to link audio chain; audio disabled");
-            return false;
+            warn!("Webcam: failed to link mic chain; audio disabled");
+            return (false, false);
+        }
+        if gst::Element::link_many([&tee, &queue_spec, &spectrum, &level, &audio_sink]).is_err() {
+            warn!("Webcam: failed to link spectrum branch; audio disabled");
+            return (false, false);
         }
 
         info!("Webcam: microphone audio branch attached ({mic_factory})");
-        true
+
+        // Raw PCM appsink branch. Failures here degrade to has_pcm=false ──
+        // but leave the spectrum branch running.
+        let queue_pcm = match gst::ElementFactory::make("queue").name("webcam_q_pcm").build() {
+            Ok(e) => e,
+            Err(_) => {
+                warn!("Webcam: failed to create PCM queue; raw PCM disabled");
+                return (true, false);
+            }
+        };
+        let pcm_sink = match gst::ElementFactory::make("appsink")
+            .name("webcam_pcm_sink")
+            .build()
+        {
+            Ok(e) => e,
+            Err(_) => {
+                warn!("Webcam: failed to create PCM appsink; raw PCM disabled");
+                return (true, false);
+            }
+        };
+        let pcm_appsink = match pcm_sink.dynamic_cast::<gst_app::AppSink>() {
+            Ok(a) => a,
+            Err(_) => {
+                warn!("Webcam: failed to cast PCM sink; raw PCM disabled");
+                return (true, false);
+            }
+        };
+        pcm_appsink.set_caps(Some(
+            &gst::Caps::builder("audio/x-raw")
+                .field("format", "F32LE")
+                .field("rate", PCM_SAMPLE_RATE as i32)
+                .field("channels", 1i32)
+                .build(),
+        ));
+        pcm_appsink.set_max_buffers(8);
+        pcm_appsink.set_drop(true);
+        pcm_appsink.set_sync(false);
+
+        let pcm_buffer = pcm_samples.clone();
+        pcm_appsink.set_callbacks(
+            gst_app::AppSinkCallbacks::builder()
+                .new_sample(move |sink| {
+                    let sample = sink.pull_sample().map_err(|_| gst::FlowError::Eos)?;
+                    let buffer = sample.buffer().ok_or(gst::FlowError::Error)?;
+                    let map = buffer.map_readable().map_err(|_| gst::FlowError::Error)?;
+                    let bytes = map.as_slice();
+                    // F32LE little-endian on all supported targets (x86_64,
+                    // aarch64) — direct cast is safe.
+                    let samples: &[f32] = bytemuck::cast_slice(bytes);
+                    if let Ok(mut q) = pcm_buffer.lock() {
+                        for &s in samples {
+                            if q.len() >= PCM_BUFFER_CAP {
+                                q.pop_front();
+                            }
+                            q.push_back(s);
+                        }
+                    }
+                    Ok(gst::FlowSuccess::Ok)
+                })
+                .build(),
+        );
+
+        if pipeline.add(&pcm_appsink).is_err() {
+            warn!("Webcam: failed to add PCM appsink; raw PCM disabled");
+            return (true, false);
+        }
+        if pipeline.add(&queue_pcm).is_err() {
+            warn!("Webcam: failed to add PCM queue; raw PCM disabled");
+            return (true, false);
+        }
+        if gst::Element::link_many([&tee, &queue_pcm, pcm_appsink.upcast_ref::<gst::Element>()])
+            .is_err()
+        {
+            warn!("Webcam: failed to link PCM branch; raw PCM disabled");
+            return (true, false);
+        }
+
+        info!("Webcam: raw PCM tap attached ({PCM_SAMPLE_RATE} Hz mono f32)");
+        (true, true)
     }
 
     /// Poll the GStreamer bus for spectrum/level messages from the webcam's

--- a/usage.md
+++ b/usage.md
@@ -369,6 +369,8 @@ Cuneus supports **bidirectional GPU-CPU audio workflows** using two complementar
 - **Shader Access**: `@group(2) var<storage, read> audio_spectrum: array<f32>` (read-only)
 - **Use Case**: Audio visualizers like `audiovis.rs`
 
+**Raw PCM access (host-side):** both `WebcamTextureManager` and `VideoTextureManager` also expose the time-domain waveform via `pop_pcm_samples(n)` — mono `f32` at 44.1kHz in a bounded ring buffer. Use it when you need raw samples instead of FFT magnitudes. Samples stay host-side unless you upload them yourself. Check `has_pcm()` before draining.
+
 **2. Audio Synthesis (`.with_audio()`)** - Generate music on GPU:
 - **Flow**: GPU computes raw PCM samples per-frame → CPU reads back → `PcmStreamManager` streams to audio output
 - **Shader Access**: `@group(2) var<storage, read_write> audio_buffer: array<f32>` (read-write)


### PR DESCRIPTION
Adds a parallel raw PCM tap to the gst audio pipeline in both WebcamTextureManager (live mic) and VideoTextureManager (loaded media files),  exposing mono f32 samples at 44.1kHz through a new uniform API: has_pcm(), pcm_sample_rate(), pcm_available(), pop_pcm_samples(n). The samples land in a bounded ring buffer (oldest dropped when full), kept host-side... nothing is uploaded to the GPU unless the consumer does it. The existing spectrum/level/playback paths and the shader-facing audio_spectrum buffer are unchanged; the tap is additive and falls back to the original linear chain if any tap element fails to build...