### PR TITLE
increase chances of successful local builds for the passers-by

### DIFF
--- a/.github/workflows/no-default-features.yaml
+++ b/.github/workflows/no-default-features.yaml
@@ -1,0 +1,26 @@
+name: No Default Features
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  check:
+    name: cargo check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Check without default features
+        run: cargo check --workspace --all-targets --no-default-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,4 +34,64 @@ ply-rs-bw = "4.0"
 default = ["media"]
 media = ["gstreamer", "gstreamer-video", "gstreamer-app", "gstreamer-pbutils"]
 
+[[example]]
+name = "audiovis"
+required-features = ["media"]
+
+[[example]]
+name = "blockgame"
+required-features = ["media"]
+
+[[example]]
+name = "bugberman"
+required-features = ["media"]
+
+[[example]]
+name = "computecolors"
+required-features = ["media"]
+
+[[example]]
+name = "debugscreen"
+required-features = ["media"]
+
+[[example]]
+name = "fft"
+required-features = ["media"]
+
+[[example]]
+name = "fluid"
+required-features = ["media"]
+
+[[example]]
+name = "gaussian"
+required-features = ["media"]
+
+[[example]]
+name = "kuwahara"
+required-features = ["media"]
+
+[[example]]
+name = "lego"
+required-features = ["media"]
+
+[[example]]
+name = "pathtracing"
+required-features = ["media"]
+
+[[example]]
+name = "synth"
+required-features = ["media"]
+
+[[example]]
+name = "tameimp"
+required-features = ["media"]
+
+[[example]]
+name = "veridisquo"
+required-features = ["media"]
+
+[[example]]
+name = "voronoi"
+required-features = ["media"]
+
 [dev-dependencies]

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,4 @@
-// Purpose: This build script configures the build environment for GStreamer integration.
+// Purpose: This build script configures the build environment for optional GStreamer integration.
 //
 // What this does:
 // - Sets up necessary paths, environment variables and linker flags for GStreamer
@@ -27,6 +27,12 @@ use std::env;
 use std::path::PathBuf;
 
 fn main() {
+    println!("cargo:rerun-if-env-changed=CARGO_FEATURE_MEDIA");
+
+    if env::var_os("CARGO_FEATURE_MEDIA").is_none() {
+        return;
+    }
+
     let target = env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
 
     match target.as_str() {

--- a/src/renderkit.rs
+++ b/src/renderkit.rs
@@ -1115,13 +1115,13 @@ impl RenderKit {
     }
 
     /// Update current active texture and return whether an external texture update is needed
-    pub fn update_current_texture(&mut self, core: &Core, queue: &wgpu::Queue) -> bool {
+    pub fn update_current_texture(&mut self, _core: &Core, _queue: &wgpu::Queue) -> bool {
         #[cfg(feature = "media")]
         {
             if self.using_video_texture {
-                return self.update_video_texture(core, queue);
+                return self.update_video_texture(_core, _queue);
             } else if self.using_webcam_texture {
-                return self.update_webcam_texture(core, queue);
+                return self.update_webcam_texture(_core, _queue);
             }
         }
         // Static textures don't need updates


### PR DESCRIPTION
Thanks for this amazing project, I always love to have my computer show me pretty graphics. And as the cherry on top, these ones are very hackable should I ever be inclined.

This PR is motivated to fix the initial issues I had building it, which nearly drove me away. It's a minimal way of increasing the chances of successful builds, by better handling the already optional "media" feature.

I added CI checks for good measure. Something I left out is a CI check that includes "media" examples, as it needs the installation of dependencies and I didn't want to spend time fiddling with CI.

The most contention commit might the the last one which removes "media" from default features so it's trivial to build examples that don't need it, while showing a message that makes clear what to do for where it is needed.

Now running the blackhole shader works as expected:

```bash
❯ cargo run --release --example blackhole
   Compiling cuneus v0.6.2 (/Users/byron/dev/github.com/altunenes/cuneus)
    Finished [`release` profile [optimized]](https://doc.rust-lang.org/cargo/reference/profiles.html#default-profiles) target(s) in 4.98s
     Running `target/release/examples/blackhole`
```

Whereas other example will be explicit about what they need:

```bash
❯ cargo run --release --example fluid
error: target `fluid` in package `cuneus` requires the features: `media`
Consider enabling them by passing, e.g., `--features="media"
```

AI Disclosure: The PR text is written by me, the commits and commit messages are by Codex. I reviewed each one hunk by hunk, and possibly edited the commit messages.

### Notes for the review

I encourage you to edit everything at will with `gh pr checkout 178` and just force-push into the PR to make it fit your needs. No need for a lot of back and forth, and closing it is also fine of course. This is a flyby, which cost me no more than 15 minutes.
