### PR TITLE
Add DeviceLimits enum and Core::new_with_limits

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,4 +1,4 @@
-use crate::{Core, ShaderManager};
+use crate::{Core, DeviceLimits, ShaderManager};
 use log::error;
 use winit::{
     application::ApplicationHandler,
@@ -11,6 +11,7 @@ use winit::{
 pub struct ShaderApp {
     window_title: String,
     window_size: (u32, u32),
+    device_limits: DeviceLimits,
     core: Option<Core>,
 }
 
@@ -24,10 +25,19 @@ impl ShaderApp {
         let app = Self {
             window_title: String::from(window_title),
             window_size: (width, height),
+            device_limits: DeviceLimits::default(),
             core: None,
         };
 
         (app, event_loop)
+    }
+
+    /// Request the adapter's full limits instead of wgpu's default.
+    ///
+    /// Opt in for large buffers and grids on capable GPUs. See [`DeviceLimits`].
+    pub fn with_adapter_limits(mut self) -> Self {
+        self.device_limits = DeviceLimits::Adapter;
+        self
     }
 
     pub fn run<S: ShaderManager + 'static>(
@@ -71,7 +81,7 @@ impl<S: ShaderManager> ApplicationHandler for ShaderAppHandler<S> {
             .create_window(window_attributes)
             .expect("Failed to create window");
         window.set_window_level(winit::window::WindowLevel::AlwaysOnTop);
-        let core = pollster::block_on(Core::new(window));
+        let core = pollster::block_on(Core::new_with_limits(window, self.app.device_limits));
         // Initialize the shader with the core if it hasn't been initialized yet
         if let Some(shader_creator) = self.shader_creator.take() {
             let shader = shader_creator(&core);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,7 @@ pub mod prelude {
         compute::ComputeShader, compute::ComputeShaderBuilder, compute::MultiPassManager,
         compute::PassDescription, compute::StorageBufferSpec,
         compute::COMPUTE_TEXTURE_FORMAT_RGBA16, compute::COMPUTE_TEXTURE_FORMAT_RGBA8,
-        save_frame, CharInfo, ControlsRequest, Core, ExportManager, FontSystem,
+        save_frame, CharInfo, ControlsRequest, Core, DeviceLimits, ExportManager, FontSystem,
         FontUniforms, KeyInputHandler, RenderKit, Renderer, ShaderApp, ShaderControls,
         FrameContext, ShaderHotReload, ShaderManager, TextureManager, UniformBinding,
         UniformProvider,
@@ -218,6 +218,20 @@ macro_rules! compute_shader {
     }};
 }
 
+/// Which device limits to request at creation.
+///
+/// Defaults to [`DeviceLimits::Default`] wgpu's portable limits
+/// Opt into [`DeviceLimits::Adapter`] for large buffers and
+/// grids on capable hw.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum DeviceLimits {
+    /// wgpu's portable defaults.
+    #[default]
+    Default,
+    /// Everything the adapter reports
+    Adapter,
+}
+
 pub struct Core {
     pub surface: wgpu::Surface<'static>,
     pub device: Arc<wgpu::Device>,
@@ -228,6 +242,10 @@ pub struct Core {
 }
 impl Core {
     pub async fn new(window: Window) -> Self {
+        Self::new_with_limits(window, DeviceLimits::Default).await
+    }
+
+    pub async fn new_with_limits(window: Window, limits: DeviceLimits) -> Self {
         let size = window.inner_size();
         let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle());
         let window_box = Box::new(window);
@@ -249,11 +267,15 @@ impl Core {
             })
             .await
             .unwrap();
+        let required_limits = match limits {
+            DeviceLimits::Default => wgpu::Limits::default(),
+            DeviceLimits::Adapter => adapter.limits(),
+        };
         let (device, queue) = adapter
             .request_device(&wgpu::DeviceDescriptor {
                 label: None,
                 required_features: wgpu::Features::empty(),
-                required_limits: wgpu::Limits::default(),
+                required_limits,
                 memory_hints: Default::default(),
                 experimental_features: Default::default(),
                 trace: wgpu::Trace::default(),


### PR DESCRIPTION
This adds a DeviceLimits enum and ShaderApp::with_adapter_limits(). Default stays default. Could be useful if you work with bigger buffers, grids, and workgroups... 